### PR TITLE
Set up basic schema detail page

### DIFF
--- a/core/static/site.css
+++ b/core/static/site.css
@@ -1,18 +1,25 @@
 html {
   background: #222;
   --text-primary: #fff;
-  --text-secondary: #ccc;
+  --text-secondary: #bbb;
   color: var(--text-primary);
 }
 
 
 h1 {
   font-size: 24px;
+  color: var(--text-primary);
+}
+
+h2 {
+  color: var(--text-secondary);
+  font-size: 18px;
 }
 
 a {
   color: var(--text-primary);
   text-decoration: underline;
+  cursor: pointer;
 }
 
 input {
@@ -20,6 +27,11 @@ input {
   padding: 0.5rem;
   background: #444;
   color: var(--text-primary)
+}
+
+.icon {
+  width: 1rem;
+  height: 1rem;
 }
 
 .text-primary {
@@ -30,15 +42,7 @@ input {
   color: var(--text-secondary);
 }
 
-.homepage {
-  margin: 1rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-}
-
-.homepage .overview {
+.main-content {
   width: 100%;
   max-width: 60rem;
   background: #333;
@@ -50,6 +54,34 @@ input {
   gap: 1rem;
 }
 
+.homepage {
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
 .homepage .schema-list {
   line-height: 2;
+}
+
+.schema-detail {
+  margin: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+.schema-detail .back-link {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  align-self: flex-start;
+  text-decoration: none;
+}
+
+.schema-detail .back-link:hover {
+  text-decoration: underline;
 }

--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -6,8 +6,8 @@ Schema Index
 {% block content %}
 <main class="homepage">
   <h1>Schema Index</h1>
-  <h2 class="text-secondary">An open source registry for schema files</h2>
-  <section class="overview">
+  <h2>An open source registry for schema files</h2>
+  <section class="main-content">
     <form action="" method="GET">
       <input
         name="search_query"
@@ -32,7 +32,9 @@ Schema Index
     </p>
     <ul class="schema-list">
       {% for schema in schemas %}
-      <li><a href="{{ schema.schemaref_set.last.url }}">{{ schema.name }}</a></li>
+      <li>
+        <a href="{% url 'schema_detail' schema_id=schema.id %}">{{ schema.name }}</a>
+      </li>
       {% endfor %}
     </ul>
   </section>

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -1,0 +1,34 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+{{ schema.name }} - Schema Index
+{% endblock %}
+
+{% block content %}
+<main class="schema-detail">
+  <a class="back-link" href="{% url 'index' %}">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
+    </svg>
+    Schema Index
+  </a>
+  <h1>{{ schema.name }}</h1>
+  <section class="main-content">
+    {% if schema.schemaref_set.exists %}
+    <h2>Reference links:</h2>
+    <ul>
+      {% for schema_ref in schema.schemaref_set.all|dictsortreversed:"created_by" %}
+      <li><a href="{{schema_ref.url}}">{{schema_ref.url}}</a></li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+    {% if schema.documentationitem_set.exists %}
+    <h2>Documentation links:</h2>
+    <ul>
+      {% for documentation_item in schema.documentationitem_set.all|dictsort:"name" %}
+      <li><a href="{{documentation_item.url}}">{{documentation_item.name}}</a>
+      {% endfor %}
+    </ul>
+    {% endif %}
+  </section>
+</main>
+{% endblock %}

--- a/core/urls.py
+++ b/core/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path("", views.index, name="index")
+    path("", views.index, name="index"),
+    path("schemas/<int:schema_id>", views.schema_detail, name="schema_detail")
 ]
 

--- a/core/views.py
+++ b/core/views.py
@@ -1,11 +1,10 @@
-from django.shortcuts import render
+from django.shortcuts import render, get_object_or_404
 from django.db.models import Count
 from .models import Schema
 
 MAX_SCHEMA_RESULT_COUNT = 30
 
 def index(request):
-
     defined_schemas = (
         Schema.objects
         .prefetch_related("schemaref_set")
@@ -19,3 +18,15 @@ def index(request):
         "total_schema_count": defined_schemas.count(),
         "schemas": results.order_by("name")[:MAX_SCHEMA_RESULT_COUNT]
     })
+
+
+def schema_detail(request, schema_id):
+    schema = get_object_or_404(
+        Schema.objects.prefetch_related("schemaref_set").prefetch_related("documentationitem_set"),
+        pk=schema_id
+    )
+
+    return render(request, "core/schemas/detail.html", {
+        "schema": schema
+    })
+


### PR DESCRIPTION
Closes #5.

Adds schemas detail page that lists reference links and documentation items with a link back to the hompage. Also updates the home page to list to detail pages instead of directly to reference links.

<img width="1253" height="393" alt="Screenshot From 2025-08-20 17-03-23" src="https://github.com/user-attachments/assets/09fa002f-cd0d-446d-a726-db98a5afd508" />
<img width="1253" height="393" alt="Screenshot From 2025-08-20 17-03-31" src="https://github.com/user-attachments/assets/87f591c7-9d54-4c94-8b48-1b96cff242af" />
