### PR TITLE
Implement URL validation for new schemas

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,12 +1,72 @@
 from django import forms
+from django.core.exceptions import ValidationError
+import requests
+from pygments.lexers import get_lexer_for_filename
+from pygments.util import ClassNotFound
 from .models import DocumentationItem
+
+'''
+This is currently just a list of languages supported
+by our syntax highlighter, Highlight.js, *without plaintext.*
+You can regenerate this list by loading up the site,
+opening a JS REPL in the browser's dev tools,
+and executing `hljs.listLanguanges()`.
+
+Note that the actual allowlist is an intersection
+of this list and the lexers from pygments.
+'''
+SPECIFICATION_LANGUAGE_ALLOWLIST = [
+"bash","c","cpp","csharp","css","diff","go","graphql","ini","java","javascript","json","kotlin","less","lua","makefile","markdown","objectivec","perl","php","php-template","python","python-repl","r","ruby","rust","scss","shell","sql","swift","typescript","vbnet","wasm","xml","yaml"
+]
 
 class SchemaForm(forms.Form):
     name = forms.CharField(label="Schema name", max_length=200)
     reference_url = forms.URLField(label="Schema definition URL")
     readme_url = forms.URLField(label="Schema README URL")
     readme_format = forms.ChoiceField(
-        choices=list(DocumentationItem.DocumentationItemFormat.choices) + [('', 'Other')],
+        choices=DocumentationItem.DocumentationItemFormat.choices,
         required=False,
         label="README format"
     )
+
+    def _clean_url(self, url_field_name, language_allowlist):
+        data = self.cleaned_data[url_field_name]
+        try:
+            response = requests.get(data)
+        except requests.exceptions.RequestException:
+            raise ValidationError("The provided URL could not be reached")
+
+        if response.status_code != requests.codes.ok:
+            raise ValidationError("The provided URL returned an invalid status code")
+
+        if not response.text:
+            raise ValidationError("The provided URL has no text content")
+
+        # Use pygments to verify the language from the filename
+        try:
+            lexer = get_lexer_for_filename(data)
+        except ClassNotFound:
+            if not "plaintext" in language_allowlist:
+                raise ValidationError("The provided URL does not have a supported file extension")
+            else:
+                # If we don't have a match but plaintext is allowed, we'll just treat it as plaintext
+                return [data, "plaintext"]
+
+        matched_language = next(
+            (alias for alias in language_allowlist if alias in lexer.aliases),
+            "plaintext" if "plaintext" in language_allowlist else None
+        )
+        if not matched_language:
+            raise ValidationError("The text content at the provided URL is not in a supported format")
+
+        return [data, matched_language]
+
+    def clean_reference_url(self):
+        [data, matched_language] = self._clean_url('reference_url', language_allowlist=SPECIFICATION_LANGUAGE_ALLOWLIST)
+        return data
+
+    def clean_readme_url(self):
+        [data, matched_language] = self._clean_url('readme_url', language_allowlist=DocumentationItem.DocumentationItemFormat)
+        self.readme_format = matched_language
+        return data
+

--- a/core/models.py
+++ b/core/models.py
@@ -48,6 +48,7 @@ class DocumentationItem(ReferenceItem):
 
     class DocumentationItemFormat(models.TextChoices):
         Markdown = 'markdown'
+        PlainText = 'plaintext'
 
     name = models.CharField(max_length=300)
     description = models.TextField(blank=True, null=True)

--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -7,6 +7,7 @@ html {
   --primary-color-highlight: #4f46e5;
   --danger-color: #b91c1c;
   --danger-color-highlight: #991b1b;
+  --danger-color-text: #f87171;
   background: #222;
   color: var(--text-primary);
   font-family: sans-serif;
@@ -318,7 +319,7 @@ a.button-link--primary:hover {
 
 .field__label--is-required:after {
   content: '*';
-  color: red;
+  color: var(--danger-color-text);
 }
 
 .field--checkbox {
@@ -335,6 +336,10 @@ a.button-link--primary:hover {
 
 .field--checkbox label {
   cursor: pointer;
+}
+
+.field .errorlist {
+  color: var(--danger-color-text);
 }
 
 .markdown {

--- a/core/templates/core/manage/schema.html
+++ b/core/templates/core/manage/schema.html
@@ -13,11 +13,14 @@ Edit Schema
     <form action="{% if is_new %}{% url 'manage_schema_new' %}{% else %}{% url 'manage_schema' schema_id=schema.pk %}{% endif %}" method="POST">
       {% csrf_token %}
       {% for field in form %}
-      <div class="field">
-        <label for="{{ field.id_for_label }}" class="{% if field.field.required %}field__label--is-required{% endif %}">
+      <div class="field{% if field.errors %} field--has-errors{% endif %}">
+        <label
+          for="{{ field.id_for_label }}"
+          class="{% if field.field.required %}field__label--is-required{% endif %}">
           {{ field.label }}
         </label>
         {{ field }}  
+        {{ field.errors }}
       </div>
       {% endfor %}
       <button type="submit" class="button button--prominent">{% if is_new %}Add schema{% else %}Save{% endif %}</button>

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Django==5.2.5
 django-allauth==65.11.0
 idna==3.10
 pycparser==2.22
+Pygments==2.19.2
 requests==2.32.5
 sqlparse==0.5.3
 urllib3==2.5.0


### PR DESCRIPTION
Closes #20.

Ensures user-input URLs meet the following requirements:
:heavy_check_mark: Return a 200 status
:heavy_check_mark: Have text content
:heavy_check_mark: (Schemas) Have a supported file extension

I spent a bit too long trying to get the file type/language from the text content but this proved fairly tricky, so I ended up just going based on file extension instead. This means that all URLs for Schemas *must* have a supported file extension. For READMEs, anything that isn't Markdown but has text content will just be treated as plaintext. I'm not 100% confident about this strategy.