### PR TITLE
Fix: Deploy to GCP using Artifact Registry previously created

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -127,11 +127,18 @@ jobs:
           export GS_BUCKET_NAME=$(python3 -c "from django.conf import settings; print(settings.GS_BUCKET_NAME)")
           gcloud storage buckets update gs://$GS_BUCKET_NAME --cors-file=gcp-cors-config.json
 
+      - name: Build and push Docker image
+        run: >
+          gcloud builds submit
+          --region us-central1
+          --tag us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/schemaindex-stg-registry/schemaindex:latest
+          .
+
       - name: Deploy to Cloud Run
         run: >
           gcloud run deploy ${{ vars.CLOUD_RUN_SERVICE_NAME }}
           --region us-central1
-          --source .
+          --image us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/schemaindex-stg-registry/schemaindex:latest
           --service-account ${{ vars.SERVICE_ACCOUNT_NAME }}
           --set-env-vars DJANGO_SETTINGS_MODULE="${{ vars.DJANGO_SETTINGS_MODULE }}"
           --set-env-vars DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}"

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -25,14 +25,14 @@ GS_BUCKET_NAME = 'schemaindex-stg-storage'
 # Use Cloud Storage for static and media files
 STORAGES = {
     "default": {
-        "BACKEND": "storages.backends.gcp.GoogleCloudStorage",
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "logos",
         }
     },
     "staticfiles": {
-        "BACKEND": "storages.backends.gcp.GoogleCloudStorage",
+        "BACKEND": "storages.backends.gcloud.GoogleCloudStorage",
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "site-assets",


### PR DESCRIPTION
This PR fix an issue we had in our previously deployment attempts where Cloud Run tries to create a default Artifact Registry and not using the one we previously created so this was causing some IAM permissions issues.