### PR TITLE
Setup PostgreSQL db for staging env (necessary due to PostgreSQL GCP instance) and update ALLOWED_HOSTS with actual staging URL

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'schemaindex.settings')
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'schemaindex.settings.base')
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -5,13 +5,21 @@ This inherits from base settings and adds Cloud Run specific configuration.
 """
 
 import os
+import environ
 from .base import *
 
 # Override base settings for staging environment
 DEBUG = False
 
-# Temporary - will update with real Cloud Run URL after first deployment
-ALLOWED_HOSTS = ['*']
+# Update ALLOWED_HOSTS with actual Cloud Run URL
+ALLOWED_HOSTS = ['schemaindex-stg-run-799626592344.us-central1.run.app']
+
+# Use PostgreSQL if environment variable exists, otherwise inherit SQLite from base.py
+if 'DJ_DATABASE_CONN_STRING' in os.environ:
+    env = environ.Env()
+    DATABASES = {
+        'default': env.db('DJ_DATABASE_CONN_STRING')
+    }
 
 # CSRF and CORS configuration for staging
 CSRF_TRUSTED_ORIGINS = [


### PR DESCRIPTION
The Cloud Run staging deployment was failing with database errors because the app was using SQLite instead of PostgreSQL, resulting in "no such table: core_schema" errors when accessing the application.

- **Updated staging settings**: Added environment variable fallback for PostgreSQL database connection
- **Fixed ALLOWED_HOSTS**: Updated with actual Cloud Run URL instead of wildcard
- **Fixed local development**: Updated manage.py to use base.py settings by default

## Changes
### `schemaindex/settings/staging.py`
- Added PostgreSQL configuration using `DJ_DATABASE_CONN_STRING` environment variable
- Falls back to SQLite (from base.py) if environment variable not present
- Updated `ALLOWED_HOSTS` with actual Cloud Run URL: `schemaindex-stg-run-799626592344.us-central1.run.app`

### `manage.py`
- Changed default settings module from `schemaindex.settings` to `schemaindex.settings.base`
- Ensures local development uses SQLite while Cloud Run uses PostgreSQL

## Testing
- Local development continues to work with SQLite
- Cloud Run deployment now properly connects to PostgreSQL Cloud SQL database
- Resolves 500 errors and database table not found issues

Fixes the staging environment database connectivity and maintains proper separation between local and cloud environments.
