### PR TITLE
fix: add PostgreSQL env variable to GitHub Actions build steps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,11 +117,13 @@ jobs:
       - name: Collect static files
         env:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          DJ_DATABASE_CONN_STRING: postgres://${{ secrets.POSTGRES_CREDENTIALS }}@localhost:1234/schemaindex_staging
         run: python3 manage.py collectstatic --no-input
 
       - name: Configure CORS for storage bucket
         env:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          DJ_DATABASE_CONN_STRING: postgres://${{ secrets.POSTGRES_CREDENTIALS }}@localhost:1234/schemaindex_staging
         run: |
           python3 manage.py create_gcp_cors_config
           export GS_BUCKET_NAME=$(python3 -c "from django.conf import settings; print(settings.GS_BUCKET_NAME)")

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -14,28 +14,12 @@ DEBUG = False
 # Update ALLOWED_HOSTS with actual Cloud Run URL
 ALLOWED_HOSTS = ['schemaindex-stg-run-799626592344.us-central1.run.app']
 
-# Debug: Check environment variable
-print("=== STAGING SETTINGS DEBUG ===")
-print(f"DJ_DATABASE_CONN_STRING present: {'DJ_DATABASE_CONN_STRING' in os.environ}")
-if 'DJ_DATABASE_CONN_STRING' in os.environ:
-    print(f"Database URL: {os.environ['DJ_DATABASE_CONN_STRING']}")
-
-# Use PostgreSQL if environment variable exists, otherwise inherit SQLite from base.py  
+# Use PostgreSQL if environment variable exists, otherwise inherit SQLite from base.py
 if 'DJ_DATABASE_CONN_STRING' in os.environ:
     env = environ.Env()
-    try:
-        DATABASES = {
-            'default': env.db('DJ_DATABASE_CONN_STRING')
-        }
-        print(f"PostgreSQL config loaded: {DATABASES['default']['ENGINE']}")
-    except Exception as e:
-        print(f"Error parsing database URL: {e}")
-        print(f"Falling back to SQLite from base.py")
-else:
-    print("No DJ_DATABASE_CONN_STRING found, using SQLite from base.py")
-
-print(f"Final DATABASES: {DATABASES}")
-print("=== END DEBUG ===")
+    DATABASES = {
+        'default': env.db('DJ_DATABASE_CONN_STRING')
+    }
 
 # CSRF and CORS configuration for staging
 CSRF_TRUSTED_ORIGINS = [


### PR DESCRIPTION
Django management commands in GitHub Actions (collectstatic, CORS config) were failing to connect to PostgreSQL and falling back to SQLite because the `DJ_DATABASE_CONN_STRING` environment variable wasn't available during build time.

- **Runtime**: Cloud Run had correct environment variables
- **Build time**: GitHub Actions didn't set `DJ_DATABASE_CONN_STRING` for Django commands
- **Result**: Commands used SQLite from base.py instead of PostgreSQL from staging.py