### PR TITLE
fix: Resolve database URL parsing by encoding special characters in credentials

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -99,6 +99,34 @@ jobs:
         with:
           project_id: ${{ vars.GCP_PROJECT_ID }}
 
+      - name: URL-encode database credentials for special characters
+        env:
+          POSTGRES_CREDENTIALS: ${{ secrets.POSTGRES_CREDENTIALS }}
+        run: |
+          # URL encode credentials to handle special characters like *, !, (, )
+          # Extract and encode password securely without exposing it in logs
+          ENCODED_CREDENTIALS=$(python3 -c "
+          import urllib.parse, os, sys
+          try:
+              creds = os.environ['POSTGRES_CREDENTIALS']
+              if ':' in creds:
+                  user, password = creds.split(':', 1)
+                  encoded_password = urllib.parse.quote(password, safe='')
+                  print(f'{user}:{encoded_password}')
+              else:
+                  print(creds)
+          except Exception:
+              sys.exit(1)
+          ")
+          
+          if [ $? -eq 0 ]; then
+            echo "ENCODED_DB_CREDENTIALS=$ENCODED_CREDENTIALS" >> $GITHUB_ENV
+            echo "Database credentials encoded successfully"
+          else
+            echo "Failed to encode database credentials"
+            exit 1
+          fi
+
       - name: Download and run the Cloud SQL Auth Proxy
         run: |
           curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.10.1/cloud-sql-proxy.linux.amd64
@@ -107,7 +135,7 @@ jobs:
 
       - name: Run migrations
         env:
-          DJ_DATABASE_CONN_STRING: postgres://${{ secrets.POSTGRES_CREDENTIALS }}@localhost:1234/schemaindex_staging
+          DJ_DATABASE_CONN_STRING: postgres://${{ env.ENCODED_DB_CREDENTIALS }}@localhost:1234/schemaindex_staging
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         run: python3 manage.py migrate
 
@@ -117,13 +145,13 @@ jobs:
       - name: Collect static files
         env:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-          DJ_DATABASE_CONN_STRING: postgres://${{ secrets.POSTGRES_CREDENTIALS }}@localhost:1234/schemaindex_staging
+          DJ_DATABASE_CONN_STRING: postgres://${{ env.ENCODED_DB_CREDENTIALS }}@localhost:1234/schemaindex_staging
         run: python3 manage.py collectstatic --no-input
 
       - name: Configure CORS for storage bucket
         env:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
-          DJ_DATABASE_CONN_STRING: postgres://${{ secrets.POSTGRES_CREDENTIALS }}@localhost:1234/schemaindex_staging
+          DJ_DATABASE_CONN_STRING: postgres://${{ env.ENCODED_DB_CREDENTIALS }}@localhost:1234/schemaindex_staging
         run: |
           python3 manage.py create_gcp_cors_config
           export GS_BUCKET_NAME=$(python3 -c "from django.conf import settings; print(settings.GS_BUCKET_NAME)")
@@ -144,5 +172,5 @@ jobs:
           --service-account ${{ vars.SERVICE_ACCOUNT_NAME }}
           --set-env-vars DJANGO_SETTINGS_MODULE="${{ vars.DJANGO_SETTINGS_MODULE }}"
           --set-env-vars DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}"
-          --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ secrets.POSTGRES_CREDENTIALS }}/cloudsql/${{ secrets.CLOUD_SQL_ICN }}/schemaindex_staging"
+          --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}/cloudsql/${{ secrets.CLOUD_SQL_ICN }}/schemaindex_staging"
           --allow-unauthenticated


### PR DESCRIPTION
The PostgreSQL password contains special characters. When Django's django-environ tried to parse the database connection string the URL parser got confused and interpreted a part of the password as a port number instead of a password, causing the error in the Google Cloud Logs:

```text
ValueError: Port could not be cast to integer value as 'JKe4SsNa*rSK4(!a'
```

Added secure URL encoding step in GitHub Actions workflow that:

- **Encodes special characters** in database password using `urllib.parse.quote()`
- **Maintains security** by not exposing credentials in GitHub logs
- **Works universally** for both build-time (Cloud SQL proxy) and runtime (Cloud Run) connections
- **Updated all database connections** to use encoded credentials (`ENCODED_DB_CREDENTIALS`)
