### PR TITLE
fix: correct Cloud Run database connection string format

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -172,5 +172,5 @@ jobs:
           --service-account ${{ vars.SERVICE_ACCOUNT_NAME }}
           --set-env-vars DJANGO_SETTINGS_MODULE="${{ vars.DJANGO_SETTINGS_MODULE }}"
           --set-env-vars DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}"
-          --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}/cloudsql/${{ secrets.CLOUD_SQL_ICN }}/schemaindex_staging"
+          --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}@//cloudsql/${{ secrets.CLOUD_SQL_ICN }}/schemaindex_staging"
           --allow-unauthenticated


### PR DESCRIPTION
Cloud Run deployment continued failing with database URL parsing errors despite implementing URL encoding for special characters:
```
ValueError: Port could not be cast to integer value as '[Password goes here]'
```

While URL encoding resolved special character handling, the database connection string format was incorrect.

**Current Schema Index Connection String (broken):**
```yaml
postgres://${{ env.ENCODED_DB_CREDENTIALS }}/cloudsql/instance/database
```

The Cloud Run database connection string format was fixed by adding:
- **`@` symbol** after credentials
- **`//` prefix** before `/cloudsql/` path

```yaml
# Before:
DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}/cloudsql/..."

# After:
DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}@//cloudsql/..."
```