### PR TITLE
fix: Add Cloud SQL instance connection to Cloud Run service

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -170,6 +170,7 @@ jobs:
           --region us-central1
           --image us-central1-docker.pkg.dev/${{ vars.GCP_PROJECT_ID }}/schemaindex-stg-registry/schemaindex:latest
           --service-account ${{ vars.SERVICE_ACCOUNT_NAME }}
+          --add-cloudsql-instances=${{ secrets.CLOUD_SQL_ICN }}
           --set-env-vars DJANGO_SETTINGS_MODULE="${{ vars.DJANGO_SETTINGS_MODULE }}"
           --set-env-vars DJANGO_SECRET_KEY="${{ secrets.DJANGO_SECRET_KEY }}"
           --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}@//cloudsql/${{ secrets.CLOUD_SQL_ICN }}/schemaindex_staging"


### PR DESCRIPTION
Cloud Run deployment was failing with database socket connection errors despite Django starting successfully and having correct URL formatting:
```
connection to server on socket "/cloudsql/schemaindex-staging:us-central1:schemaindex-stg-sql/.s.PGSQL.5432" failed: No such file or directory
```

Cloud Run service was missing the explicit Cloud SQL instance connection configuration. Even though:
- ✅ Service account had Cloud SQL Client role
- ✅ Database URL format was correct
- ✅ Cloud SQL instance was running

Cloud Run doesn't automatically mount Cloud SQL Unix sockets unless explicitly configured.

Added missing `--add-cloudsql-instances` flag to Cloud Run deployment:

```yaml
# Before:
gcloud run deploy SERVICE_NAME --service-account SA --set-env-vars ...

# After:
gcloud run deploy SERVICE_NAME 
  --add-cloudsql-instances=${{ secrets.CLOUD_SQL_ICN }}
  --service-account SA 
  --set-env-vars ...
```