### PR TITLE
fix: Configure Google Cloud Storage to not use signed URLs

### DIFF
--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -38,6 +38,7 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "logos",
+            "querystring_auth": False,
         }
     },
     "staticfiles": {
@@ -45,6 +46,7 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "site-assets",
+            "querystring_auth": False,
         }
     }
 }


### PR DESCRIPTION
Cloud Run deployment was failing with Google Cloud Storage signing errors when rendering static files in Django templates:

```
AttributeError: you need a private key to sign credentials... 
<class 'google.auth.compute_engine.credentials.Credentials'> just contains a token
```

Despite having a properly configured public Google Cloud Storage bucket, `django-storages` was attempting to generate **signed URLs** for static files. Cloud Run's compute engine credentials only contain tokens, not the private keys required for URL signing.