### PR TITLE
Add sidebar to schema detail page

### DIFF
--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -442,6 +442,23 @@ a.button-link--primary:hover {
   gap: 1rem;
 }
 
+.schema-detail .content {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.schema-detail .sidebar {
+  width: 15rem;
+  background: #333;
+  padding: 1rem;
+  border-radius: 8px;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .schema-definition {
   max-height: 50rem;
   overflow: auto;

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -10,33 +10,40 @@
 {% block page_content %}
 <main class="schema-detail">
   <h1>{{ schema.name }}</h1>
-  <section class="main-content">
-    {% if latest_readme_content %}
-    <h2>Latest README:</h2>
-    <div class="markdown">
-      {{ latest_readme_content }}
-    </div>
-    {% endif %}
-    {% if latest_definition %}
-    <h2>Latest definition:</h2>
-    <pre class="schema-definition"><code>{{ latest_definition|escape }}</code></pre>
-    {% endif %}
-    {% if schema.schemaref_set.exists %}
-    <h2>Reference links:</h2>
-    <ul>
-      {% for schema_ref in schema.schemaref_set.all|dictsortreversed:"created_by" %}
-      <li><a href="{{schema_ref.url}}">{{schema_ref.url}}</a></li>
-      {% endfor %}
-    </ul>
-    {% endif %}
-    {% if schema.documentationitem_set.exists %}
-    <h2>Documentation links:</h2>
-    <ul>
-      {% for documentation_item in schema.documentationitem_set.all|dictsort:"name" %}
-      <li><a href="{{documentation_item.url}}">{{documentation_item.name}}</a>
-      {% endfor %}
-    </ul>
-    {% endif %}
-  </section>
+  <div class="content">
+    <section class="sidebar">
+      <h2 class="text--primary">Details</h2>
+      <p>Added on {{ schema.created_at | date }}</p>
+      <p>Managed by {{ schema.created_by }}</p>
+    </section>
+    <section class="main-content">
+      {% if latest_readme_content %}
+      <h2>Latest README:</h2>
+      <div class="markdown">
+        {{ latest_readme_content }}
+      </div>
+      {% endif %}
+      {% if latest_definition %}
+      <h2>Latest definition:</h2>
+      <pre class="schema-definition"><code>{{ latest_definition|escape }}</code></pre>
+      {% endif %}
+      {% if schema.schemaref_set.exists %}
+      <h2>Reference links:</h2>
+      <ul>
+        {% for schema_ref in schema.schemaref_set.all|dictsortreversed:"created_by" %}
+        <li><a href="{{schema_ref.url}}">{{schema_ref.url}}</a></li>
+        {% endfor %}
+      </ul>
+      {% endif %}
+      {% if schema.documentationitem_set.exists %}
+      <h2>Documentation links:</h2>
+      <ul>
+        {% for documentation_item in schema.documentationitem_set.all|dictsort:"name" %}
+        <li><a href="{{documentation_item.url}}">{{documentation_item.name}}</a>
+        {% endfor %}
+      </ul>
+      {% endif %}
+    </section>
+  </div>
 </main>
 {% endblock %}


### PR DESCRIPTION
Closes #45.

Additional sidebar content to come in #26, #27, and maybe #35. I don't know if we'll actually want to list usernames in a "managed by" line since they're really just email prefixes, but I just wanted to have some content there for now.

<img width="1281" height="609" alt="image" src="https://github.com/user-attachments/assets/791fbfcd-35ab-4dd3-9741-789693ddde66" />
