### PR TITLE
Fix: Exclude current schema when checking for duplicate URLs

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -87,7 +87,7 @@ def manage_schema(request, schema_id=None):
     schema = get_object_or_404(Schema.objects.filter(created_by=request.user), pk=schema_id) if schema_id else None
 
     if request.method == 'POST':
-        form = SchemaForm(request.POST)
+        form = SchemaForm(request.POST, schema=schema)
         if form.is_valid():
             schema = schema if schema else Schema.objects.create(created_by=request.user)
             schema.name = form.cleaned_data['name']
@@ -113,15 +113,7 @@ def manage_schema(request, schema_id=None):
             return redirect('account_profile')
 
     else:
-        latest_reference = schema.latest_reference() if schema else None
-        latest_readme = schema.latest_readme() if schema else None
-        initial = {
-            'name': schema.name,
-            'reference_url': latest_reference.url if latest_reference else None,
-            'readme_url': latest_readme.url if latest_readme else None,
-            'readme_format': latest_readme.format if latest_readme else None,
-        } if schema else None
-        form = SchemaForm(initial)
+        form = SchemaForm(schema=schema)
 
     return render(request, "core/manage/schema.html", {
         'schema': schema,


### PR DESCRIPTION
Follow up to #44, related to #25.

#44 didn't work properly when saving existing schemas as the duplicate URL detection logic failed to exclude the schema that was being changed when looking for duplicate URLs. Thus, every existing schema URL would be reported as a "duplicate" when it was really being compared to itself, which obviously already exists in the database. Whoops!

I also migrated setting `initial` data into the new initializer.
