### PR TITLE
fix: Add explicit Google Cloud Storage service account credentials

### DIFF
--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -7,6 +7,7 @@ This inherits from base settings and adds Cloud Run specific configuration.
 import os
 import sys
 import environ
+from google.oauth2 import service_account
 from .base import *
 
 # Override base settings for staging environment
@@ -31,6 +32,11 @@ CSRF_TRUSTED_ORIGINS = [
 # Google Cloud Storage configuration
 GS_BUCKET_NAME = 'schemaindex-stg-storage'
 
+# Explicit service account credentials for Google Cloud Storage
+GS_CREDENTIALS = service_account.Credentials.from_service_account_file(
+    "service-account-credentials.json"
+)
+
 # Use Cloud Storage for static and media files
 STORAGES = {
     "default": {
@@ -38,7 +44,6 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "logos",
-            "querystring_auth": False,
         }
     },
     "staticfiles": {
@@ -46,7 +51,6 @@ STORAGES = {
         "OPTIONS": {
             "bucket_name": GS_BUCKET_NAME,
             "location": "site-assets",
-            "querystring_auth": False,
         }
     }
 }


### PR DESCRIPTION
I found out that Cloud Run staging deployment was failing with Google Cloud Storage signing credential errors when dealing with static files:
```
AttributeError: you need a private key to sign credentials.
The credentials you are currently using <google.auth.compute_engine.credentials.Credentials> just contains a token.
```

- We need to use explicit service account credentials with private keys via `GS_CREDENTIALS`
- django-storages can generate signed URLs using those private keys