### PR TITLE
fix: Adding EMAILs missing configuration

### DIFF
--- a/schemaindex/settings/production.py
+++ b/schemaindex/settings/production.py
@@ -85,3 +85,5 @@ EMAIL_USE_TLS = True
 EMAIL_USE_SSL = False
 EMAIL_HOST_USER = "noreply@dtinit.org"
 EMAIL_HOST_PASSWORD = env.str('EMAIL_HOST_PASSWORD')
+DEFAULT_FROM_EMAIL = "noreply@dtinit.org"
+SERVER_EMAIL = "noreply@dtinit.org"


### PR DESCRIPTION
PR that adds DEFAULT_FROM_EMAIL and SERVER_EMAIL to try and solve the Email Delivery Fails.

Close #91 

--

We had an undefined DEFAULT_FROM_EMAIL which was probably the cause of the inconsistent behavior.

It seems that when `DEFAULT_FROM_EMAIL` is not explicitly set, Django's email system has unpredictable fallback behavior:

- **Sometimes** it uses `EMAIL_HOST_USER` ([[noreply@dtinit.org](mailto:noreply@dtinit.org)](mailto:noreply@dtinit.org)) (**Correct domain**)
- **Sometimes** it defaults to `webmaster@localhost` (Wrong domain)
- **Sometimes** allauth uses its own internal logic to construct From addresses

When the From address happened to be `noreply@dtinit.org`, SPF/DKIM checks passed and email went through. When it was `webmaster@localhost` or something else, authentication failed → 450 error.

Staging (which already has the DEFAULT_FROM_EMAIL and SERVER_EMAIL changes) makes no use of `webmaster@localhost`
<img width="1246" height="472" alt="image" src="https://github.com/user-attachments/assets/f8219ef7-6cff-4a89-a55b-0e8c6162f53e" />

But Production does
<img width="1272" height="652" alt="image" src="https://github.com/user-attachments/assets/8f732990-d8c5-4770-b13f-bef260e1c8f9" />

Now I am just monitoring that everything is working as expected but testing has been good so far.