### PR TITLE
ci-cd: Production tagging and GitHub release job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,5 +1,3 @@
-# Schema Index CI/CD Pipeline
-
 name: CI/CD
 
 on:
@@ -12,6 +10,12 @@ on:
       environment:
         type: environment
         description: Select the target environment
+        default: 'Staging'
+        required: true
+      perform_deploy:
+        description: 'Set to true to perform actual deployment'
+        required: true
+        type: boolean
 
 jobs:
   # Test Python/Django code with PostgreSQL database
@@ -56,15 +60,18 @@ jobs:
 
   # Deploy to Google Cloud Run (staging environment)
   deploy:
-    # Only deploy on push to main or manual trigger
+    # Only deploy on push to main or manual trigger with perform_deploy=true
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main')
-        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'workflow_dispatch' && inputs.perform_deploy)
     # Wait for tests to pass
     needs: [test-python]
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment || 'Staging' }}
+      url: ${{ steps.extract_deployment_url.outputs.url }}
+    outputs:
+      url: ${{ steps.extract_deployment_url.outputs.url }}
     env:
       DJANGO_SETTINGS_MODULE: ${{ vars.DJANGO_SETTINGS_MODULE }}
       # Temporary placeholder - real value passed during Cloud Run deployment
@@ -88,6 +95,14 @@ jobs:
         with:
           name: service-account-credentials.json
           json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Extract deployment URL
+        id: extract_deployment_url
+        continue-on-error: true
+        env:
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+        run: |
+          python -c "from django.conf import settings; print(f'url=https://{settings.ALLOWED_HOSTS[0]}')" >> $GITHUB_OUTPUT
 
       - uses: 'google-github-actions/auth@v2'
         with:
@@ -169,3 +184,52 @@ jobs:
           --set-env-vars DJ_DATABASE_CONN_STRING="postgres://${{ env.ENCODED_DB_CREDENTIALS }}@//cloudsql/${{ secrets.CLOUD_SQL_ICN }}/${{ vars.DATABASE_NAME }}"
           --set-env-vars EMAIL_HOST_PASSWORD="${{ secrets.EMAIL_HOST_PASSWORD }}"
           --allow-unauthenticated
+
+  create-release:
+    if: inputs.environment == 'Production'
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.create-tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: 'Configure git user'
+        run: |
+          git config user.name "Github Actions"
+          git config user.email "github-actions@users.noreply.github.com"
+
+      - name: 'Create git tag'
+        id: create-tag
+        run: |
+          timestamp=$(date -u +'%Y-%m-%d-%H-%M-%S')Z
+          base_tag="production-$timestamp"
+          tag="$base_tag"
+          retry=0
+          
+          # Check if tag exists and add retry suffix if needed
+          while git ls-remote --tags origin | grep -q "refs/tags/$tag"; do
+            retry=$((retry + 1))
+            tag="$base_tag-r$retry"
+          done
+          
+          git tag "$tag"
+          git push origin "$tag"
+          echo "tag=$tag" >> $GITHUB_OUTPUT
+
+      - name: 'Create GitHub release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_body=""
+          if [ -n "${{ needs.deploy.outputs.url }}" ]; then
+            release_body="**Deployment URL:** ${{ needs.deploy.outputs.url }}"
+          fi
+          
+          gh release create ${{ steps.create-tag.outputs.tag }} \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="${{ steps.create-tag.outputs.tag }}" \
+            --notes="$release_body" \
+            --generate-notes


### PR DESCRIPTION
Based on Alex work with Trust Registry


Trigger Type | Previous Behavior | New Behavior
-- | -- | --
Push to main | Always deploys to Staging | Always deploys to Staging (no change)
PR | No deploy | No deploy (no change)
Manual run (Staging, perform_deploy=false) | Would deploy | Now skips deploy
Manual run (Staging, perform_deploy=true) | Would deploy | Deploys to Staging (no release)
Manual run (Production, perform_deploy=false) | Would deploy | Now skips deploy
Manual run (Production, perform_deploy=true) | Would deploy | Deploys to Production + creates tag/release

Close #84 