### PR TITLE
Adds the ability in main page to list multiple schema definitions (SchemaRef objects) if the Schema has them. 

### DIFF
--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -46,9 +46,10 @@
         {% if latest_readme_content %}
         <li><button class="tab-link" data-tab-link="readme">README</button></li>
         {% endif %}
-        {% if latest_definition %}
-        <li><button class="tab-link" data-tab-link="schema">Schema</button></li>
-        {% endif %}
+        {% for schemaref in schemarefs %}
+        <li><button class="tab-link" data-tab-link="schema{{ forloop.counter }}">
+            Schema {% if schema.schemaref_set.count > 1 %}{{ forloop.counter }}{% endif %}</button></li>
+        {% endfor %}
         {% if schema.documentationitem_set.exists %}
         <li><button class="tab-link" data-tab-link="docs">Docs</button></li>
         {% endif %}
@@ -64,14 +65,12 @@
           {% endif %}
         </li>
         {% endif %}
-        {% if latest_definition %}
-        <li data-tab-id="schema" class="inactive-tab schema-tab">
-          <pre class="schema-definition"><code>{{ latest_definition|escape }}</code></pre>
-          {% if latest_definition_url %}
-          <a href="{{ latest_definition_url }}">View source</a>
-          {% endif %}
+        {% for schemaref in schemarefs %}
+        <li data-tab-id="schema{{ forloop.counter }}" class="inactive-tab schema-tab">
+          <pre class="schema-definition"><code>{{ schemaref.content|escape }}</code></pre>
+          <a href="{{ schemaref.url }}">View source</a>
         </li>
-        {% endif %}
+        {% endfor %}
         {% if schema.documentationitem_set.exists %}
         <li data-tab-id="docs" class="inactive-tab schema-tab">
           <ul>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,9 +5,12 @@ from factories import UserFactory
 
 @pytest.mark.django_db
 def test_multiple_schemarefs():
+    # A simple test but leaving it in as I used it to debug a simple thing
     user = UserFactory.create()
     my_schema = Schema.objects.create(name="Star Trek", created_by=user)
     ship_schema = SchemaRef.objects.create(schema=my_schema, url="https://example.com/ships", created_by=user)
     station_schema = SchemaRef.objects.create(schema=my_schema, url="https://example.com/stns", created_by=user)
     assert Schema.objects.all().count() == 1
+    assert my_schema.schemaref_set.count() == 2
+
 


### PR DESCRIPTION
Further work: 
* SchemaRefs should maybe have names instead of numbers
* the 'get' request in the view that fills in the fake content property of the schemarefs is a bit of a hack - further work could make the content property of the SchemaRef be a method that is accessible as a property (see https://stackoverflow.com/questions/58558989/what-does-djangos-property-do) and it could hit a cache if we want it to

Note also: the change in the view from
         Schema.objects.prefetch_related("schemaref_set").filter(schemaref__isnull=False)
to
         Schema.objects.prefetch_related("schemaref_set").exclude(schemaref__isnull=True)
is not an accident; this didn't show up when we only had one schemaref per schema, but the first form of the query somehow creates multiple schema instances, one per schemaref it has, and that was causing duplicates to appear in the index list.  . 