### PR TITLE
CI-CD: Update Production URLs in production settings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -102,7 +102,7 @@ jobs:
         env:
           DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
         run: |
-          python -c "from django.conf import settings; print(f'url=https://{settings.ALLOWED_HOSTS[0]}')" >> $GITHUB_OUTPUT
+          python -c "from django.conf import settings; print(f'url=https://{settings.SITE_URL}')" >> $GITHUB_OUTPUT
 
       - uses: 'google-github-actions/auth@v2'
         with:

--- a/schemaindex/settings/production.py
+++ b/schemaindex/settings/production.py
@@ -6,10 +6,10 @@ from google.oauth2 import service_account
 from .base import *
 
 DEBUG = False
-ALLOWED_HOSTS = [
-    '.run.app', 
+ALLOWED_HOSTS = [ 
     'schemas.pub',
     'www.schemas.pub',
+    'schemaindex-prod-run-768243509223.us-central1.run.app'
 ]
 SITE_URL = 'https://schemas.pub'
 CSRF_TRUSTED_ORIGINS = ['https://' + url for url in ALLOWED_HOSTS]


### PR DESCRIPTION
This add the Cloud Run default URL to production settings instead of having a wildcard for all possible Cloud Run URLs.

Plus also fix the deployment URL for each release.

I will use this PR to also test the newly `create-release` feature.