### PR TITLE
Make tab-links scroll on overflow

### DIFF
--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -466,6 +466,7 @@ a.button-link--primary:hover {
   justify-content: flex-start;
   gap: 2rem;
   border-bottom: 1px solid #555;
+  overflow: auto;
 }
 
 .tab-link {


### PR DESCRIPTION
Fixes #121.

This is a quick fix which isn't perfect as not every browser will show signifiers for the scrollability. But, it should hold us over until the new design.

<img width="785" height="157" alt="Screenshot From 2025-11-12 10-48-27" src="https://github.com/user-attachments/assets/1bdcaaed-d890-420b-bf47-4080978bbc54" />
<img width="785" height="157" alt="Screenshot From 2025-11-12 10-48-34" src="https://github.com/user-attachments/assets/89b0a827-0013-46be-bdd0-148d78cb79bd" />
