### PR TITLE
Fix documentation item formset clearing on append

### DIFF
--- a/core/static/js/site.js
+++ b/core/static/js/site.js
@@ -73,8 +73,7 @@
           /__prefix__/g,
           currentFormItemCount.toString()
         );
-        formsetListElement.innerHTML =
-          formsetListElement.innerHTML + nextFormItemHtml;
+        formsetListElement.insertAdjacentHTML('beforeend', nextFormItemHtml);
         const totalFormInput = formsetListElement.querySelector(
           'input[name="form-TOTAL_FORMS"]'
         );


### PR DESCRIPTION
Fixes #127.

This ended up being easy to fix. The problem was we were replacing the entire formset's HTML which wiped input values.