### PR TITLE
Ensure highlight.js is always called

### DIFF
--- a/core/static/js/schema-detail.js
+++ b/core/static/js/schema-detail.js
@@ -1,20 +1,31 @@
 (() => {
-  const hljsScriptSrc = document.getElementById('hljs-src');
-  if (!hljsScriptSrc) {
-    return;
-  }
-  const hljsScriptSrcLoaded = new Promise((resolve) => {
-    hljsScriptSrc.addEventListener('load', resolve);
-  });
-
-  const domContentLoaded = new Promise((resolve) => {
-    document.addEventListener('DOMContentLoaded', resolve);
-  });
-
-  Promise.all([hljsScriptSrcLoaded, domContentLoaded]).then(() => {
-    // TODO: figure out why we can't declare this in globals.d.ts
-    /** @type window & {hljs: {highlightAll: () => void }} */ (
-      window
-    ).hljs.highlightAll();
+  document.addEventListener('DOMContentLoaded', () => {
+    /**
+     * @import { HLJSApi } from 'highlight.js';
+     * @type Promise<HLJSApi>
+     */
+    const hljsPromise = new Promise((resolve, reject) => {
+      if (window.hljs) {
+        resolve(window.hljs);
+        return;
+      }
+      const hljsScriptSrc = document.getElementById('hljs-src');
+      if (!hljsScriptSrc) {
+        reject(new Error('A Highlight.js script tag was not found.'));
+        return;
+      }
+      hljsScriptSrc.addEventListener('load', () => {
+        if (!window.hljs) {
+          reject(new Error('Highlight.js failed to initialize.'));
+          return;
+        }
+        resolve(window.hljs);
+      });
+    });
+    hljsPromise
+      .then((hljs) => hljs.highlightAll())
+      .catch((err) => {
+        console.error(err);
+      });
   });
 })();

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,8 +1,7 @@
-interface WindowWithHljs extends Window {
-  hljs: {
-    highlightAll: () => void
+import { HLJSApi } from 'highlight.js';
+
+declare global {
+  interface Window {
+    hljs?: HLJSApi;
   }
 }
-declare const window: WindowWithHljs;
-
-export {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@eslint/js": "^9.39.0",
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
+        "highlight.js": "^11.11.1",
         "husky": "^9.1.7",
         "lint-staged": "^16.2.6",
         "prettier": "^3.6.2",
@@ -837,6 +838,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/husky": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@eslint/js": "^9.39.0",
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
+    "highlight.js": "^11.11.1",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.6",
     "prettier": "^3.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,6 @@
     "strict": true,
     "lib": ["es2015", "DOM"]
   },
-  "include": ["core/static/js/**/*"]
+  "include": ["core/static/js/**/*", "globals.d.ts"]
 }
 


### PR DESCRIPTION
(Probably) Fixes #113.

I was never able to reproduce this organically but I was able to fake it with same carefully placed artificial delays.

There were a couple potential issues with the original implementation:
1. The `load` event of the highlight.js script tag could theoretically fire *before* our listener was attached. This would cause our code to get stuck waiting for an event that would never fire again.
    - Solution: The highlight.js script creates a global `hljs` variable once it initializes. Our code will now check for that, and either proceed if it exists, or attach the `load` event handler and wait for it when `hljs` hasn't been defined yet.
2. Our code wasn't waiting for the DOM to be loaded before attempting to get the highlight.js script tag. If the tag wasn't found, the script would just bail out. I'm less confident this was actually a contributing factor, but I eliminated the possibility anyway.
    - Solution: All our highlight.js initialization code will now wait for `DOMContentLoaded`.
    
I also added some client-side error logging to help diagnose issues in the future, and fixed some TypeScript stuff.