### PR TITLE
Add Lucide and replace Heroicons

### DIFF
--- a/core/static/js/site.js
+++ b/core/static/js/site.js
@@ -172,5 +172,9 @@
         }
       );
     }, MESSAGE_TIMEOUT_MS);
+
+    if (window.lucide) {
+      window.lucide.createIcons();
+    }
   });
 })();

--- a/core/templates/account/profile.html
+++ b/core/templates/account/profile.html
@@ -26,15 +26,11 @@ Account
         </div>
         <div class="schema__action-group">
           <a href="{% url 'manage_schema' schema_id=schema.pk %}">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-            </svg>
+            <i data-lucide="square-pen" class="icon--md"></i>
           </a>
           {% if not schema.published_at|exists_and_is_in_past %}
           <a href="{% url 'manage_schema_delete' schema_id=schema.pk %}">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-              <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
-            </svg>
+            <i data-lucide="trash" class="icon--md"></i>
           </a>
           {% endif %}
         </div>

--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -8,6 +8,7 @@ Schemas.Pub - A public schema registry
   <h1 class="logo">
     <span class="color-logo">{</span>
     Schemas
+    {# We're using a filled star here as opposed to Lucide's unfilled star #}
     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon--sm color-logo logo__star">
       <path fill-rule="evenodd" d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z" clip-rule="evenodd" />
     </svg>
@@ -45,9 +46,7 @@ Schemas.Pub - A public schema registry
         {% if schema.latest_rfc %}
         <ul class="schema__badges">
           <li class="badge badge--rfc">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-            </svg>
+            <i data-lucide="file-text" class="icon--sm"></i>
             RFC
           </li>
         </ul>
@@ -55,9 +54,7 @@ Schemas.Pub - A public schema registry
         {% if schema.latest_w3c %}
         <ul class="schema__badges">
           <li class="badge badge--w3c">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-            </svg>
+            <i data-lucide="file-text" class="icon--sm"></i>
             W3C
           </li>
         </ul>

--- a/core/templates/core/layouts/base.html
+++ b/core/templates/core/layouts/base.html
@@ -12,6 +12,7 @@
         <link rel="stylesheet" href="{% static 'css/preflight.css' %}" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/agate.min.css">
         <link rel="stylesheet" href="{% static 'css/site.css' %}" />
+        <script src="https://unpkg.com/lucide@latest"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js" async id="hljs-src"></script>
         <script src="{% static 'js/site.js' %}"></script>
         {% block extra_head %}
@@ -34,9 +35,7 @@
             {% if request.path|slice:"9" != '/account/' or request.path|slice:"16" == '/account/profile'  %}
             {% if request.user.is_authenticated %}
             <a href="{% url 'account_profile' %}">
-                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M17.982 18.725A7.488 7.488 0 0 0 12 15.75a7.488 7.488 0 0 0-5.982 2.975m11.963 0a9 9 0 1 0-11.963 0m11.963 0A8.966 8.966 0 0 1 12 21a8.966 8.966 0 0 1-5.982-2.275M15 9.75a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-                </svg>
+                <i data-lucide="circle-user" class="icon--md"></i>
             </a>
             {% else %}
             <div class="nav-header__auth-actions">

--- a/core/templates/core/manage/documentation_item_form.html
+++ b/core/templates/core/manage/documentation_item_form.html
@@ -1,8 +1,6 @@
 <li class="formset form-container">
   <button class="button formset__close-trigger" type="button">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-    </svg>
+    <i data-lucide="x" class="icon--md"></i>
   </button>
   <div class="split-field-container split-field-container--67-33">
     {% include "core/manage/field.html" with field=form.name %}

--- a/core/templates/core/manage/schema.html
+++ b/core/templates/core/manage/schema.html
@@ -29,9 +29,7 @@ Edit Schema
       </ul>
       <div class="formset-controls">
         <button type="button" class="button button--link" data-formset-append-to-list-id="schema_refs">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
+          <i data-lucide="plus" class="icon--md"></i>
           Add schema definition
         </button>
       </div>
@@ -49,9 +47,7 @@ Edit Schema
       </ul>
       <div class="formset-controls">
         <button type="button" class="button button--link" data-formset-append-to-list-id="documentation_items">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
+          <i data-lucide="plus" class="icon--md"></i>
           Add documentation link
         </button>
       </div>

--- a/core/templates/core/manage/schema_ref_form.html
+++ b/core/templates/core/manage/schema_ref_form.html
@@ -1,8 +1,6 @@
 <li class="formset form-container">
   <button class="button formset__close-trigger" type="button">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-      <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
-    </svg>
+    <i data-lucide="x" class="icon--md"></i>
   </button>
   <div class="split-field-container split-field-container--50-50">
     {% include "core/manage/field.html" with field=form.name %}

--- a/core/templates/core/partials/messages.html
+++ b/core/templates/core/partials/messages.html
@@ -4,6 +4,10 @@
     <li class="message{% if message.tags %} message--{{ message.tags }}{% endif %}"
       >
       <span class="message__content">
+        {% comment %}
+        We can't use Lucide here as messages are shown on pages where users input their credentials,
+        where we shouldn't include third-party scripts.
+        {% endcomment %}
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="icon--md">
           {% if not message.tags or message.tags == 'info' %}
           <path fill-rule="evenodd" d="M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 0 1 .67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 1 1-.671-1.34l.041-.022ZM12 9a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z" clip-rule="evenodd" />
@@ -16,6 +20,7 @@
         {{ message }}
       </span>                    
       <button type="button" class="message__dismissal-trigger">
+        {# see comment above about not using Lucide here #}
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="icon--md">
           <path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z" />
         </svg>

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -16,9 +16,7 @@
   {% elif latest_readme_url %}
   <div class="external-readme-link">
     <a href="{{ latest_readme_url }}">View external README
-      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-        <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-      </svg>
+      <i data-lucide="external-link" class="icon--sm"></i>
     </a>
   </div>
     {% endif %}

--- a/core/templates/core/schemas/layout.html
+++ b/core/templates/core/schemas/layout.html
@@ -18,9 +18,7 @@
       {{ schema.name }}
       {% if request.user == schema.created_by %}
       <a href="{% url 'manage_schema' schema_id=schema.id %}">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--md">
-          <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
-        </svg>
+        <i data-lucide="square-pen" class="icon--md"></i>
       </a>
       {% endif %}
     </h1>
@@ -39,18 +37,14 @@
           class="is-active"
           {% endif %}
           >
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
-          </svg>
+          <i data-lucide="file-text" class="icon--sm"></i>
           README
         </a>
       </li>    
       {% endif %}
       {% if schema.additional_documentation_items.count > 0 %}
       <li class="nav-group__section-header">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
-        </svg>
+        <i data-lucide="book" class="icon--sm"></i>
         Documentation
       </li>
       <ul class="nav-group">
@@ -58,9 +52,7 @@
         <li>
           <a href="{{ documentation_item.url }}">
             {{ documentation_item.name }}
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-            </svg>
+            <i data-lucide="external-link" class="icon--sm"></i>
           </a>
         </li>
         {% endfor %}
@@ -81,9 +73,7 @@
             class="is-active"
             {% endif %}
             >
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M14.25 9.75 16.5 12l-2.25 2.25m-4.5 0L7.5 12l2.25-2.25M6 20.25h12A2.25 2.25 0 0 0 20.25 18V6A2.25 2.25 0 0 0 18 3.75H6A2.25 2.25 0 0 0 3.75 6v12A2.25 2.25 0 0 0 6 20.25Z" />
-            </svg>
+            <i data-lucide="code" class="icon--sm"></i>
             {% if schema_ref.name %}
             {{ schema_ref.name }}
             {% elif schema.schemaref_set.count == 1 %}
@@ -107,9 +97,7 @@
       <li>
         <a href="{{ latest_license.url }}">
           License
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="icon--sm">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-          </svg>
+          <i data-lucide="external-link" class="icon--sm"></i>
         </a>
       </li>
     </ul>

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -1,7 +1,9 @@
 import { HLJSApi } from 'highlight.js';
+import * as Lucide from 'lucide';
 
 declare global {
   interface Window {
     hljs?: HLJSApi;
+    lucide?: typeof Lucide;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "schemaindex",
       "version": "1.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "lucide": "^0.561.0"
+      },
       "devDependencies": {
         "@eslint/js": "^9.39.0",
         "eslint": "^9.39.0",
@@ -1102,6 +1105,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lucide": {
+      "version": "0.561.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.561.0.tgz",
+      "integrity": "sha512-XsOpN41YD1B5b05biTZhjlgPiiHXeRD9lqDmo30BKypzuXNiPKEXsGlsdvfHPa6CLP0Wv8Z2OYk2AHPrYkg5rw==",
+      "license": "ISC"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "lint-staged": "^16.2.6",
     "prettier": "^3.6.2",
     "typescript": "^5.9.3"
+  },
+  "dependencies": {
+    "lucide": "^0.561.0"
   }
 }


### PR DESCRIPTION
Closes #150.

Adds Lucide and replaces Heroicons throughout the app.

There are two places where I left the existing SVG Heroicons:
1. The star of the Schemas.Pub logo on the homepage, because Lucide's star is an unfilled outline.
2. Messages, because we use them on the auth pages where users enter credentials, and while I'm sure Lucide can be trusted it's easier to just not include third-party scripts on our auth pages and eliminate the risk.