### PR TITLE
Use parsed URL path when validating SchemaRef URLs

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse
 from django import forms
 from django.core.exceptions import ValidationError
 from django.db.models import Q
@@ -86,10 +87,11 @@ class SchemaRefForm(ReferenceItemForm):
             return None
 
         data = clean_url(self.cleaned_data['url'])
+        parsed_url = urlparse(data)
 
         # Use pygments to verify the language from the filename
         try:
-            lexer = get_lexer_for_filename(data)
+            lexer = get_lexer_for_filename(parsed_url.path)
         except ClassNotFound:
             raise ValidationError("The provided URL does not have a supported file extension")
 

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -51,7 +51,8 @@ def test_schema_management_form_allows_duplicate_private_urls():
 @pytest.mark.parametrize("spec_url, expect_success",
                          [['http://example.com/schema.cddl', True],
                            ['', False],
-                           ['http://example.com/schema.BOGUS', False]])
+                           ['http://example.com/schema.BOGUS', False],
+                            ['http://example.com/schema.cddl?param=hello#anchor', True]])
 def test_clean_url(spec_url, expect_success):
     with requests_mock.Mocker() as m:
         m.get(spec_url, text='{}')


### PR DESCRIPTION
Closes #132.

When cleaning URLs for `SchemaRef`s, actually parse the URL and use just the path for file type detection so we ignore things like query params.