### PR TITLE
Render markdown schema definitions

### DIFF
--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -419,6 +419,16 @@ a.button--primary:hover {
   margin: 1rem 0;
 }
 
+.markdown table th,
+.markdown table td {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #666;
+}
+
+.markdown table tr:nth-child(2n) {
+  background: #333;
+}
+
 .main-content {
   width: 100%;
   max-width: 60rem;

--- a/core/templates/core/schemas/detail_schema_ref.html
+++ b/core/templates/core/schemas/detail_schema_ref.html
@@ -20,8 +20,14 @@
   {% else %}
   <h2>Unnamed definition</h2>
   {% endif %}
+  {% if schema_ref.markdown %}
+  <div class="markdown">
+    {{ schema_ref.markdown }}
+  </div>
+  {% else %}
   <!-- Please don't add whitespace to this line!-->
   <pre class="schema-definition"><code>{{ schema_ref.content|escape }}</code></pre>
+  {% endif %}
   <p>
     <a href="{{ schema_ref.url }}">View source</a>
   </p>

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,23 @@
+from urllib.parse import urlparse
+from pygments.lexers import get_lexer_for_filename
+from pygments.util import ClassNotFound
+
+
+def guess_language_by_extension(url, languages):
+    """
+    Given a URL file path and a list of languages, returns the matching
+    language from the list, or None if no such match exists.
+    See https://pygments.org/languages/ ("Short names")
+    for a list of guessable languages.
+    """
+    parsed_url = urlparse(url)
+    try:
+        lexer = get_lexer_for_filename(parsed_url.path)
+    except ClassNotFound:
+        return None
+
+    return next(
+        (alias for alias in languages if alias in lexer.aliases),
+        None
+    )
+


### PR DESCRIPTION
Closes #79.

Adds markdown rendering for schema definitions, plus support for markdown tables.

<img width="1276" height="673" alt="image" src="https://github.com/user-attachments/assets/2d7dfc56-bede-4a1b-8420-ad5d6db77a35" />
