### PR TITLE
Revert testing logs added in previous PR

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -74,9 +74,6 @@ def render_markdown(markdown_source_text):
 # ---- Views ----
 
 def index(request):
-    logger = logging.getLogger(__name__)
-    logger.info("Schema Index main page accessed")
-    
     defined_schemas = (
         Schema.public_objects
         .prefetch_related("schemaref_set")
@@ -85,13 +82,6 @@ def index(request):
 
     search_query = request.GET.get('search_query', None)
     results = defined_schemas.filter(name__icontains=search_query) if search_query else defined_schemas
-
-    if search_query:
-        results_count = results.count()
-        logger.info(f"Search performed: query='{search_query}', results_count={results_count}")
-        
-        if results_count == 0:
-            logger.warning(f"Search returned no results: query='{search_query}'")
 
     return render(request, "core/index.html", {
         "total_schema_count": defined_schemas.count(),


### PR DESCRIPTION
This revert the logs that I merged on PR #161 and test implementation from #158.

The implementation worked as expected.

We can now include logging.

<img width="914" height="137" alt="image" src="https://github.com/user-attachments/assets/2cddbb17-6717-467d-a680-e046275a7860" />

I add loggings in Testbed with the following format

```python
def index(request):
    logger = logging.getLogger(__name__) # This could be added at the beginning of the file
    logger.info("Schema Index main page accessed")
    ....
    ....
    if search_query:
        results_count = results.count()
        logger.info(f"Search performed: query='{search_query}', results_count={results_count}")

        if results_count == 0:
            logger.warning(f"Search returned no results: query='{search_query}'")
```

I tested our logging implementation in Staging. I needed to add some roles to certain service accounts and I did the same process for Production so when we merge everything should be working the same way as Staging.