### PR TITLE
Render an extra empty formset for a schema definition if none exist

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -104,7 +104,6 @@ class DocumentationItemForm(ReferenceItemForm):
     )
 
 
-SchemaRefFormsetFactory = forms.formset_factory(SchemaRefForm, extra=0)
 DocumentationItemFormsetFactory = forms.formset_factory(DocumentationItemForm, extra=0)
 
 class SchemaForm(forms.Form):
@@ -135,6 +134,7 @@ class SchemaForm(forms.Form):
         super().__init__(*args, **kwargs)
         if schema == None:
             self.additional_documentation_items_formset = DocumentationItemFormsetFactory(prefix="documentation_items", *args, **kwargs)
+            SchemaRefFormsetFactory = forms.formset_factory(SchemaRefForm, extra=1)
             self.schema_refs_formset = SchemaRefFormsetFactory(prefix="schema_refs", *args, **kwargs)
             return
 
@@ -162,6 +162,9 @@ class SchemaForm(forms.Form):
             'name': schema_ref.name,
             'url': schema_ref.url,
         } for schema_ref in schema.schemaref_set.all()]
+        # If there aren't any schema_refs, render the formset with an extra empty formset item
+        extra_formset_item_count = max(1 - len(initial_schema_refs_formset_data), 0)
+        SchemaRefFormsetFactory = forms.formset_factory(SchemaRefForm, extra=extra_formset_item_count)
         self.schema_refs_formset = SchemaRefFormsetFactory(prefix="schema_refs", initial=initial_schema_refs_formset_data, *args, **kwargs)
         for schema_ref_form in self.schema_refs_formset:
             schema_ref_form.schema_id = schema.id


### PR DESCRIPTION
Closes #170.

This is a UX improvement for the schema management form. Previously, when creating a new schema, the form would initialize without an empty formset item for a schema definition, like this:
<img width="1011" height="932" alt="image" src="https://github.com/user-attachments/assets/ea740e93-cd05-4e97-9c8d-b1abac7ed7f8" />

This is a little confusing and annoying because at least one schema definition is required for all schemas, a requirement that was easy to miss without the fields present initially. If the user does manage to notice before submitting the form, they'd understandably wonder why we were forcing them to click "Add schema definition."

With this PR, we initialize the schema management form with an "extra" empty formset item when there aren't any `SchemRefs` for the schema, as in the case of a new schema. That way the form will initialize like this:
<img width="1011" height="932" alt="image" src="https://github.com/user-attachments/assets/b359302f-4878-45d3-a4b0-ba40947b5a1f" />

Users can still remove all the formset
