### PR TITLE
Use `URLProviderInfo` to determine provider-specific `SchemaRef` URL equivalency

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -77,7 +77,7 @@ class SchemaRefForm(ReferenceItemForm):
             schema__in=Schema.public_objects.exclude(id=self.schema_id)
         )
         for schema_ref in schema_refs:
-            if schema_ref.has_same_domain_and_path(data):
+            if schema_ref.url_provider_info.is_same_resource(data):
                 raise ValidationError("The provided URL is already in use by another Schema")
         return data
 

--- a/core/views.py
+++ b/core/views.py
@@ -284,7 +284,7 @@ def manage_schema_publish(request, schema_id):
     conflicting_published_schema_ref = None
     for schema_ref in schema.schemaref_set.all():
         for published_schema_ref in published_schema_refs:
-            if published_schema_ref.has_same_domain_and_path(schema_ref.url):
+            if published_schema_ref.url_provider_info.is_same_resource(schema_ref.url):
                 conflicting_published_schema_ref = published_schema_ref
                 break;
         if conflicting_published_schema_ref:


### PR DESCRIPTION
Closes #178.

Updates the `URLProviderInfo` class from #163 with a method `is_same_resource` to compare a `ReferenceItem`'s URL with another URL. This allows subclasses like `GitHubURLProviderInfo` to override with custom logic (like checking it against the raw URL and repo URL). The default implementation replaces `has_same_domain_and_path` from the `ReferenceItem` model.