### PR TITLE
Prevent initializing formset items as collapsed when they have errors

### DIFF
--- a/core/templates/core/manage/documentation_item_form.html
+++ b/core/templates/core/manage/documentation_item_form.html
@@ -1,4 +1,4 @@
-<li class="formset form-container{% if form.url.value %} formset--collapsed{% endif %}">
+<li class="formset form-container{% if form.url.value and not form.errors %} formset--collapsed{% endif %}">
   <div class="schema-ref-formset__actions">
     <button class="button" type="button" data-formset-close-trigger>
       <i data-lucide="x" class="icon--md"></i>

--- a/core/templates/core/manage/schema_ref_form.html
+++ b/core/templates/core/manage/schema_ref_form.html
@@ -1,4 +1,4 @@
-<li class="formset form-container schema-ref-formset{% if form.url.value %} formset--collapsed{% endif %}">
+<li class="formset form-container schema-ref-formset{% if form.url.value and not form.errors %} formset--collapsed{% endif %}">
   <div class="schema-ref-formset__actions">
     <button class="button" type="button" data-formset-close-trigger>
       <i data-lucide="x" class="icon--md"></i>


### PR DESCRIPTION
Closes #187.

Ensures schema management formset items aren't automatically initialized in the collapsed state when they have errors.

[Screencast From 2026-02-17 15-04-48.webm](https://github.com/user-attachments/assets/cc604326-87bd-497d-927a-5da932a2311f)
