### PR TITLE
Schema detail page improvements

### DIFF
--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -807,6 +807,36 @@ a.badge--w3c {
   text-decoration: underline;
 }
 
+.schema-layout
+  .schema-layout__nav
+  .nav-group.nav-group--organization-schemas
+  li {
+  padding-left: 1.25rem;
+}
+
+.schema-layout
+  .schema-layout__nav
+  .nav-group.nav-group--organization-schemas
+  li
+  a {
+  border: 1px solid transparent;
+}
+
+.schema-layout
+  .schema-layout__nav
+  .nav-group.nav-group--organization-schemas
+  li
+  a:hover,
+.schema-layout
+  .schema-layout__nav
+  .nav-group.nav-group--organization-schemas
+  li
+  a.is-active {
+  background: #172554;
+  color: #bfdbfe;
+  border-color: #1e3a8a;
+}
+
 .schema-layout .schema-layout__nav .nav-group-label {
   color: #999;
   font-size: 12px;

--- a/core/templates/core/schemas/layout.html
+++ b/core/templates/core/schemas/layout.html
@@ -112,6 +112,27 @@
           </li>
         {% endfor %}
       </ul>
+      {% if schema.organization %}
+      <hr />
+      <div>
+        <i data-lucide="building" class="icon--sm"></i>
+        Organization
+      </div>
+      <ul class="nav-group nav-group--organization-schemas">
+        {% for org_schema in schema.organization.public_schemas|dictsort:"name" %}
+        <li>
+          <a href="{% url 'schema_detail' schema_id=org_schema.id %}"
+             {% if org_schema.id == schema.id %}
+             class="is-active"
+             {% endif %}
+             >
+            <i data-lucide="code" class="icon--sm"></i>
+            {{ org_schema.name }}
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% endif %}
     </nav>
     <main class="schema-layout__content">
       {% block schema_content %}


### PR DESCRIPTION
Closes #188. Closes #192.

- Sets a maximum width and a minimum height for the schema detail page
- Adds a border to the bottom of the schema details
- Fixes plaintext readability by preserving existing line breaks
- Adds the organization's other schemas to the left panel

<img width="2558" height="1093" alt="Screenshot From 2026-02-24 14-05-31" src="https://github.com/user-attachments/assets/cc9f3666-febc-4ef8-9242-57a364cf4f5b" />
<img width="1282" height="1056" alt="Screenshot From 2026-02-24 14-09-47" src="https://github.com/user-attachments/assets/229c0d1e-0d13-4135-ada7-b234daec8de3" />
<img width="562" height="485" alt="Screenshot From 2026-02-24 14-59-26" src="https://github.com/user-attachments/assets/b7035ae0-ac82-4e5a-ab41-471f9df9f8b2" />
