### PR TITLE
Add content caching for remote file fetches

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -6,7 +6,10 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.hashers import make_password, check_password
+from django.core.cache import cache
 from urllib.parse import urlparse
+import hashlib
+import logging
 import time
 import requests
 import requests.exceptions
@@ -16,6 +19,8 @@ from .utils import (
     guess_specification_language_by_extension,
     guess_language_by_extension,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class BaseModel(models.Model):
@@ -340,15 +345,33 @@ class ReferenceItem(BaseModel):
                 self.content_fetch_failing_since = None
         super().save(*args, **kwargs)
 
-    # TODO: Cache content and add optional param to force a refresh (GitHub issue #157)
-    def get_content(self):
+    def _get_content_url(self):
+        # Resolve the URL to fetch content from 
         if (
             self.url_provider_info.provider_name == GitHubURLInfo.provider_name
             and self.url_provider_info.raw_url
         ):
-            content_url = self.url_provider_info.raw_url
-        else:
-            content_url = self.url
+            return self.url_provider_info.raw_url
+        return self.url
+
+    def _content_cache_key(self):
+        # Build a cache key from the resolved content URL
+        content_url = self._get_content_url()
+        url_hash = hashlib.sha256(content_url.encode()).hexdigest()[:16]
+        return f"content:{url_hash}"
+
+    def get_content(self, force_refresh=False):
+        cache_key = self._content_cache_key()
+
+        # Return cached content unless a refresh is forced
+        if not force_refresh:
+            cached_content = cache.get(cache_key)
+            if cached_content is not None:
+                logger.info("Cache hit for %s", cache_key)
+                return cached_content
+
+        content_url = self._get_content_url()
+        logger.info("Cache miss for %s, fetching from %s", cache_key, content_url)
 
         # Retry logic with exponential backoff
         retries = 2
@@ -365,6 +388,9 @@ class ReferenceItem(BaseModel):
                     self.content_fetch_failing_since = None
                     self.save()
 
+                # Cache the successfully fetched content
+                cache.set(cache_key, response.text, timeout=settings.CONTENT_CACHE_TTL)
+                logger.info("Cached content for %s (TTL: %ds)", cache_key, settings.CONTENT_CACHE_TTL)
                 return response.text
             except requests.exceptions.RequestException as e:
                 last_exception = e

--- a/core/models.py
+++ b/core/models.py
@@ -8,8 +8,6 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.hashers import make_password, check_password
 from django.core.cache import cache
 from urllib.parse import urlparse
-import hashlib
-import logging
 import time
 import requests
 import requests.exceptions
@@ -19,8 +17,6 @@ from .utils import (
     guess_specification_language_by_extension,
     guess_language_by_extension,
 )
-
-logger = logging.getLogger(__name__)
 
 
 class BaseModel(models.Model):
@@ -354,24 +350,19 @@ class ReferenceItem(BaseModel):
             return self.url_provider_info.raw_url
         return self.url
 
-    def _content_cache_key(self):
-        # Build a cache key from the resolved content URL
+    def _cache_key(self):
+        # Build a cache key from the model type and primary key.
+        # Includes class name because ReferenceItem is abstract —
+        # SchemaRef pk=1 and DocumentationItem pk=1 can coexist.
+        return f"content:{self.__class__.__name__.lower()}:{self.pk}"
+
+    def _fetch_content(self):
+        """Fetch content from the remote URL with retry logic.
+        Called by cache.get_or_set on a cache miss. Failed fetches
+        raise an exception, which prevents get_or_set from caching
+        the result — so failures are never cached.
+        """
         content_url = self._get_content_url()
-        url_hash = hashlib.sha256(content_url.encode()).hexdigest()[:16]
-        return f"content:{url_hash}"
-
-    def get_content(self, force_refresh=False):
-        cache_key = self._content_cache_key()
-
-        # Return cached content unless a refresh is forced
-        if not force_refresh:
-            cached_content = cache.get(cache_key)
-            if cached_content is not None:
-                logger.info("Cache hit for %s", cache_key)
-                return cached_content
-
-        content_url = self._get_content_url()
-        logger.info("Cache miss for %s, fetching from %s", cache_key, content_url)
 
         # Retry logic with exponential backoff
         retries = 2
@@ -388,9 +379,6 @@ class ReferenceItem(BaseModel):
                     self.content_fetch_failing_since = None
                     self.save()
 
-                # Cache the successfully fetched content
-                cache.set(cache_key, response.text, timeout=settings.CONTENT_CACHE_TTL)
-                logger.info("Cached content for %s (TTL: %ds)", cache_key, settings.CONTENT_CACHE_TTL)
                 return response.text
             except requests.exceptions.RequestException as e:
                 last_exception = e
@@ -408,6 +396,14 @@ class ReferenceItem(BaseModel):
                         self.save()
 
                     raise last_exception  # Re-raise the last exception after all retries and email logic
+
+    def get_content(self):
+        """Fetch remote file content, using cache when available."""
+        return cache.get_or_set(
+            self._cache_key(),
+            self._fetch_content,
+            timeout=settings.CONTENT_CACHE_TTL,
+        )
 
     def _send_failure_notification_email(self):
         recipient_email = self.created_by.email

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -171,6 +171,17 @@ LOGGING = {
     },
 }
 
+# Cache configuration
+# Default to in-memory cache for development.
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}
+
+# Default: 1 hour
+CONTENT_CACHE_TTL = 60 * 60
+
 # Media settings
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from django.core.cache import cache
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """
+    Clear the Django cache before and after each test.
+    Prevents cached values from leaking between tests.
+    """
+    cache.clear()
+    yield
+    cache.clear()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -187,6 +187,28 @@ def test_reference_item_get_content_no_email_on_non_http_error(mock_sleep):
 
 
 @pytest.mark.django_db
+def test_reference_item_get_content_returns_cached_on_second_call():
+    """
+    After a successful fetch, subsequent calls should return
+    cached content without making another HTTP request.
+    """
+    schema_ref = SchemaRefFactory.create()
+    mock_content = "cached schema content"
+    with requests_mock.Mocker() as m:
+        m.get(schema_ref.url, text=mock_content)
+
+        # First call: fetches from remote
+        first_result = schema_ref.get_content()
+        assert first_result == mock_content
+        assert m.call_count == 1
+
+        # Second call: returns cached content, no new HTTP request
+        second_result = schema_ref.get_content()
+        assert second_result == mock_content
+        assert m.call_count == 1  # Still 1 - no second request made
+
+
+@pytest.mark.django_db
 def test_api_key_creation():
     profile = ProfileFactory.create()
     api_key = profile.set_new_api_key()


### PR DESCRIPTION
This PR adds a caching layer to `get_content()` using Django's cache framework, eliminating redundant HTTP requests when viewing schema pages. This is Part 1 of the caching work — the application-level caching logic. Part 2 (Valkey/Memorystore infrastructure for production) is a separate task. See comments on #169.

---

Every time someone views a schema page, the server makes a live HTTP GET request to the external host (GitHub, etc.) to fetch the file content. There is no caching, every visitor viewing the same schema triggers its own GET request.

The TODO on `models.py:343` explicitly tracked this: `# TODO: Cache content and add optional param to force a refresh (GitHub issue #157)`

---

Caching is implemented inside `get_content()`. Check cache first, fetch on miss, store on success. This is the standard Django caching approach, using Django's built-in cache framework (`django.core.cache`).

The default cache backend is `LocMemCache` (Django's built-in in-process memory cache), configured in `base.py`. This is the standard Django development default — it works immediately with zero infrastructure, no external services, and no extra packages. It follows the same pattern the project already uses for the database: `base.py` defaults to SQLite for development, `production.py` overrides with Cloud SQL PostgreSQL. Here, `base.py` defaults to LocMemCache, and production will override with Valkey.

LocMemCache is not suitable as the production backend because it's per-process (not shared across Cloud Run instances), but that's exactly what Part 2 addresses.

---

- Cache keys are built from the resolved content URL. Hashing keeps keys short. A URL change naturally produces a different cache key, so stale content is never served for a new URL.
- Cached content expires after a configurable TTL (default: 1 hour).
- Failed fetches are never cached. If the remote host returns an error, the failure is not stored in cache. The next request retries the fetch rather than serving a cached failure.

<details>
<summary>force_refresh parameter is for future use (I can delete it if it's not considered necessary). One situation where it would be used is as a Django admin action:</summary>


An admin wants to manually refresh a specific schema's cached content, maybe the schema owner updated their file on GitHub and doesn't want to wait for the 1-hour TTL to expire. This would be implemented as a custom admin action:

```
# In core/admin.py
@admin.action(description="Refresh cached content")
def refresh_content(modeladmin, request, queryset):
    for schema_ref in queryset:
        schema_ref.get_content(force_refresh=True)
```

</details>

---

I also included `pytest.fixture clear_cache` since Django's LocMemCache stores data in a Python dictionary that lives in the process's memory. When pytest runs, all tests execute in the same Python process. That dictionary persists across tests unless something explicitly clears it.

## Relation to #226 (API rate limiting)

This PR sets up Django's cache framework which #226 will also depend on. Rate limiting stores per-profile request counters in the cache — the middleware will use the same `django.core.cache` API. Both features will share the same Valkey backend in production after Part 2 is completed.

Valkey/Memorystore is a prerequisite for #226 in production. LocMemCache is per-process, so rate limit counters are not shared across Cloud Run instances — a user could get N requests per instance instead of N total. Valkey provides a single shared store that all instances read/write from, making rate limits enforceable.