### PR TITLE
API key authentication and rate limiting

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -1,5 +1,6 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.contrib.admin.decorators import register
+from django.core.cache import cache
 from .models import (
     Schema,
     SchemaRef,
@@ -9,6 +10,7 @@ from .models import (
     PermanentURL,
     APIKey
 )
+from .middleware.api_key_authentication_and_rate_limit import get_profile_rate_limit_key
 
 def format_date_only(obj, date_field):
     return date_field.strftime("%b. %d, %Y") if date_field else "-"
@@ -31,6 +33,7 @@ class SchemaAdmin(admin.ModelAdmin):
     def formatted_is_published(self, obj):
         return '✓' if obj.is_published else ''
 
+
 @register(SchemaRef)
 class SchemaRefAdmin(admin.ModelAdmin):
     list_display = ['name', 'schema', 'url']
@@ -49,9 +52,20 @@ class OrganizationAdmin(admin.ModelAdmin):
     list_display = ['name', 'slug']
 
 
+@admin.action(description='Reset API Rate Limits')
+def reset_rate_limit(modeladmin, request, queryset):
+    for profile in queryset:
+        # Match the key format used in your middleware
+        cache_key = get_profile_rate_limit_key(profile)
+        cache.delete(cache_key)
+    
+    messages.success(request, f'Rate limits reset for {queryset.count()} profiles.')
+
+
 @register(Profile)
 class ProfileAdmin(admin.ModelAdmin):
     list_display = ['user', 'organization']
+    actions = [reset_rate_limit]
 
 
 @register(PermanentURL)

--- a/core/api_responses.py
+++ b/core/api_responses.py
@@ -1,0 +1,13 @@
+from django.http import JsonResponse
+
+class ApiErrorResponse(JsonResponse):
+    def __init__(self, status_code, message, details=None):
+        response_body = {
+            'error': {
+                'code': status_code,
+                'message': message,
+                'details': details
+            }
+        }
+        super().__init__(response_body)
+        self.status_code = status_code

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -1,0 +1,4 @@
+from django.http import HttpResponse
+
+def find(request):
+    return HttpResponse('OK')

--- a/core/middleware/api_key_authentication_and_rate_limit.py
+++ b/core/middleware/api_key_authentication_and_rate_limit.py
@@ -36,25 +36,14 @@ class APIKeyAuthenticationAndRateLimitMiddleware:
         profile = api_key_obj.profile
         # For convenience, attach the user to the request
         request.user = profile.user
-
-        if self.has_exceeded_rate_limit(profile):
-             return ApiErrorResponse(
-                status_code=429,
-                message="Too many requests",
-                details="You have exceed your hourly request limit"
-            )
-
-        return self.get_response(request)
-
-    # Rate limits are tracked and applied per profile, not per API key.
-    # This allows users to change API keys as needed,
-    # but not as a way to circumvent rate limits.
-    # 
-    # This uses a sliding hourly window
-    # rather than resetting at the beginning of every hour.
-    # Note that it isn't atomic,
-    # but it should be fine for our current usage and limits.
-    def has_exceeded_rate_limit(self, profile):
+        # Rate limits are tracked and applied per profile, not per API key.
+        # This allows users to change API keys as needed,
+        # but not as a way to circumvent rate limits.
+        # 
+        # This uses a sliding hourly window
+        # rather than resetting at the beginning of every hour.
+        # Note that it isn't atomic,
+        # but it should be fine for our current usage and limits.
         request_log_key = get_profile_rate_limit_key(profile)
         previous_request_log = cache.get(request_log_key, [])
         now = int(time.time())
@@ -62,9 +51,14 @@ class APIKeyAuthenticationAndRateLimitMiddleware:
         # Filter out request logs from over an hour ago
         last_hour_request_log = [timestamp for timestamp in previous_request_log if timestamp > one_hour_ago]
         is_above_limit = len(last_hour_request_log) >= settings.HOURLY_API_REQUEST_LIMIT 
-        if not is_above_limit:
-            # Set the cache to our filtered list and allow it to expire in an hour.
-            last_hour_request_log.append(now)
-            cache.set(request_log_key, last_hour_request_log, timeout=3600)
+        if is_above_limit:
+            return ApiErrorResponse(
+                status_code=429,
+                message="Too many requests",
+                details="You have exceed your hourly request limit"
+            )
 
-        return is_above_limit
+        # Set the cache to our filtered list and allow it to expire in an hour.
+        last_hour_request_log.append(now)
+        cache.set(request_log_key, last_hour_request_log, timeout=3600)
+        return self.get_response(request)

--- a/core/middleware/api_key_authentication_and_rate_limit.py
+++ b/core/middleware/api_key_authentication_and_rate_limit.py
@@ -7,6 +7,9 @@ from core.api_responses import ApiErrorResponse
 
 API_KEY_HEADER = 'X-API-Key'
 
+def get_profile_rate_limit_key(profile):
+    return f'api_usage:sliding_log:{profile.id}'
+
 class APIKeyAuthenticationAndRateLimitMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
@@ -52,7 +55,7 @@ class APIKeyAuthenticationAndRateLimitMiddleware:
     # Note that it isn't atomic,
     # but it should be fine for our current usage and limits.
     def has_exceeded_rate_limit(self, profile):
-        request_log_key = f"api_usage:sliding_log:{profile.id}"
+        request_log_key = get_profile_rate_limit_key(profile)
         previous_request_log = cache.get(request_log_key, [])
         now = int(time.time())
         one_hour_ago = now - 3600

--- a/core/middleware/api_key_authentication_and_rate_limit.py
+++ b/core/middleware/api_key_authentication_and_rate_limit.py
@@ -1,0 +1,67 @@
+import time
+from django.core.cache import cache
+from django.http import JsonResponse
+from core.models import APIKey
+from django.conf import settings
+from core.api_responses import ApiErrorResponse
+
+API_KEY_HEADER = 'X-API-Key'
+
+class APIKeyAuthenticationAndRateLimitMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if not request.path.startswith("/api/"):
+            return self.get_response(request)
+
+        api_key_header = request.headers.get(API_KEY_HEADER)
+        if not api_key_header:
+            return ApiErrorResponse(
+                status_code=401,
+                message="Missing API Key",
+                details=f"Please include your API key with the {API_KEY_HEADER} header"
+            )
+           
+        api_key_obj = APIKey.objects.get_from_key(api_key_header)
+        if not api_key_obj:
+            return ApiErrorResponse(
+                status_code=401,
+                message="Invalid API key",
+            )
+            
+        profile = api_key_obj.profile
+        # For convenience, attach the user to the request
+        request.user = profile.user
+
+        if self.has_exceeded_rate_limit(profile):
+             return ApiErrorResponse(
+                status_code=429,
+                message="Too many requests",
+                details="You have exceed your hourly request limit"
+            )
+
+        return self.get_response(request)
+
+    # Rate limits are tracked and applied per profile, not per API key.
+    # This allows users to change API keys as needed,
+    # but not as a way to circumvent rate limits.
+    # 
+    # This uses a sliding hourly window
+    # rather than resetting at the beginning of every hour.
+    # Note that it isn't atomic,
+    # but it should be fine for our current usage and limits.
+    def has_exceeded_rate_limit(self, profile):
+        request_log_key = f"api_usage:sliding_log:{profile.id}"
+        previous_request_log = cache.get(request_log_key, [])
+        now = int(time.time())
+        one_hour_ago = now - 3600
+        # Filter out request logs from over an hour ago
+        last_hour_request_log = [timestamp for timestamp in previous_request_log if timestamp > one_hour_ago]
+        is_above_limit = len(last_hour_request_log) >= settings.HOURLY_API_REQUEST_LIMIT 
+        if not is_above_limit:
+            # Set the cache to our filtered list and allow it to expire in an hour.
+            last_hour_request_log.append(now)
+            cache.set(request_log_key, last_hour_request_log, timeout=3600)
+
+        return is_above_limit

--- a/core/models.py
+++ b/core/models.py
@@ -521,6 +521,9 @@ class Profile(models.Model):
 
 class APIKeyManager(models.Manager):
     def get_from_key(self, raw_api_key):
+        if not '.' in raw_api_key:
+            return None
+
         prefix, secret = raw_api_key.split('.', 1)
         try:
            api_key = self.select_related('profile').get(prefix=prefix)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,6 +1,11 @@
-from django.urls import path
+from django.urls import path, include
 
 from . import views
+from . import api_views
+
+api_endpoints = [
+    path("find", api_views.find, name="api_find")
+]
 
 urlpatterns = [
     path("", views.index, name="index"),
@@ -17,6 +22,7 @@ urlpatterns = [
     path("organization/<int:organization_id>", views.organization_detail, name="organization_detail"),
     path("o/<str:org_slug>/<path:partial_path>", views.permanent_org_url_redirect, name="permanent_org_url_redirect"),
     path("u/<uuid:uuid>", views.permanent_uuid_url_redirect, name="permanent_uuid_url_redirect"),
-    path("e/<str:email>/<path:partial_path>", views.permanent_email_url_redirect, name="permanent_email_url_redirect")
+    path("e/<str:email>/<path:partial_path>", views.permanent_email_url_redirect, name="permanent_email_url_redirect"),
+    path("api/", include(api_endpoints))
 ]
 

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -56,7 +56,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'allauth.account.middleware.AccountMiddleware'
+    'allauth.account.middleware.AccountMiddleware',
+    'core.middleware.api_key_authentication_and_rate_limit.APIKeyAuthenticationAndRateLimitMiddleware'
 ]
 
 ROOT_URLCONF = 'schemaindex.urls'
@@ -185,3 +186,5 @@ CONTENT_CACHE_TTL = 60 * 60
 # Media settings
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+
+HOURLY_API_REQUEST_LIMIT = 500

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,70 @@
+import pytest
+from django.test import Client, override_settings
+from factories import ProfileFactory
+
+def test_api_requires_key_header():
+    client = Client()
+    response = client.get('/api/find')
+    assert response.status_code == 401
+
+
+def test_api_requires_valid_api_key():
+    client = Client()
+    response = client.get(
+        '/api/find',
+        headers={'X-API-Key': 'invalid key'}
+    )
+    assert response.status_code == 401
+
+
+@pytest.mark.django_db
+def test_api_key_allows_valid_api_key():
+    client = Client()
+    profile = ProfileFactory.create()
+    raw_api_key = profile.set_new_api_key()
+    response = client.get(
+        '/api/find',
+        headers={'X-API-Key': raw_api_key}
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(HOURLY_API_REQUEST_LIMIT=2)
+def test_api_key_enforces_rate_limit():
+    client = Client()
+    profile = ProfileFactory.create()
+    raw_api_key = profile.set_new_api_key()
+    for _ in range(2):
+        response = client.get(
+            '/api/find',
+            headers={'X-API-Key': raw_api_key}
+        )
+        assert response.status_code == 200
+    blocked_response = client.get(
+        '/api/find',
+        headers={'X-API-Key': raw_api_key}
+    )
+    assert blocked_response.status_code == 429
+
+
+# Make sure the rate limit is actually for the profile, not the API keys.
+@pytest.mark.django_db
+@override_settings(HOURLY_API_REQUEST_LIMIT=2)
+def test_api_key_enforces_rate_limit_on_profile():
+    client = Client()
+    profile = ProfileFactory.create()
+    for _ in range(2):
+        raw_api_key = profile.set_new_api_key()
+        response = client.get(
+            '/api/find',
+            headers={'X-API-Key': raw_api_key}
+        )
+        assert response.status_code == 200
+    raw_api_key = profile.set_new_api_key()
+    blocked_response = client.get(
+        '/api/find',
+        headers={'X-API-Key': raw_api_key}
+    )
+    assert blocked_response.status_code == 429
+


### PR DESCRIPTION
:rotating_light: **Do not merge before #230.** :rotating_light: 

Closes #226.

Adds a middleware for validating API keys and rate limiting requests.

- API keys are passed via an `X-API-Key` header
- The default rate limit is set to 500 per hour (~8 per minute) on a sliding window but It's easy to change as it's just a Django setting. I wasn't sure where we should start so just let me know if I should adjust it.
- The limit is tracked and enforced on the entire `Profile`, so users can freely rotate API keys without bypassing rate limits
- Admins can manually reset rate limits for selected profiles through the admin page

<img width="950" height="546" alt="image" src="https://github.com/user-attachments/assets/3ddf4132-cff5-4000-a234-8f3ad42f5ef5" />
