### PR TITLE
Display existing key creation date on API key page

### DIFF
--- a/core/templates/account/api_key.html
+++ b/core/templates/account/api_key.html
@@ -15,7 +15,7 @@ API Key
     {% else %}
     <p>Create an API key to use with the Schemas.Pub API.</p>
     {% if request.user.profile.api_key %}
-    <p>Warning: Creating a new API key will invalidate your previous one.</p>
+    <p>Warning: Creating a new API key will invalidate your previous key created on {{ request.user.profile.api_key.created_at|date }}.</p>
     {% endif %}
     <form action="{% url 'account_api_key' %}" method="POST">
       {% csrf_token %}


### PR DESCRIPTION
Closes #231.

<img width="1277" height="293" alt="image" src="https://github.com/user-attachments/assets/ea8aa417-c707-4397-9713-0b1be2e0c444" />
