### PR TITLE
Adding VALKEY_URL on deploy job env level

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -127,6 +127,7 @@ jobs:
       url: ${{ steps.extract_deployment_url.outputs.url }}
     env:
       DJANGO_SETTINGS_MODULE: ${{ vars.DJANGO_SETTINGS_MODULE }}
+      VALKEY_URL: ${{ secrets.VALKEY_URL }}
       # Temporary placeholder - real value passed during Cloud Run deployment
       EMAIL_HOST_PASSWORD: 'placeholder'
 


### PR DESCRIPTION
This should fix [deploy job](https://github.com/dtinit/schemaindex/actions/runs/25329569974/job/74259763400) that previously failed

Since this is pretty small I'll merge it in order to verify if it fixed the problem