### PR TITLE
Memorystore Valkey per-instance CA for TLS

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,3 +1,4 @@
 #!include:.gitignore
 !.env-prod
 !service-account-credentials.json
+!runtime-certs/

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -156,6 +156,24 @@ jobs:
           GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
         run: printenv GCP_CREDENTIALS > service-account-credentials.json
 
+      - name: Write Valkey TLS CA (staging only)
+        # Memorystore for Valkey uses a per-instance CA.
+        # Stg GitHub environment defines VALKEY_SERVER_CA_PEM
+        # The production environment does not, so the `-n` guard makes this a no-op for production deploys.
+        # PEM contents are redirected straight to a file (never echoed)
+        env:
+          VALKEY_SERVER_CA_PEM: ${{ secrets.VALKEY_SERVER_CA_PEM }}
+        run: |
+          if [ -n "$VALKEY_SERVER_CA_PEM" ]; then
+            mkdir -p runtime-certs/valkey
+            printenv VALKEY_SERVER_CA_PEM > runtime-certs/valkey/server-ca.pem
+            chmod 0600 runtime-certs/valkey/server-ca.pem
+            echo "VALKEY_SERVER_CA=runtime-certs/valkey/server-ca.pem" >> "$GITHUB_ENV"
+            echo "Valkey TLS CA written to runtime-certs/valkey/server-ca.pem"
+          else
+            echo "VALKEY_SERVER_CA_PEM not set; skipping TLS CA setup"
+          fi
+
       - name: Extract deployment URL
         id: extract_deployment_url
         continue-on-error: true
@@ -248,6 +266,7 @@ jobs:
           --set-env-vars EMAIL_HOST_PASSWORD="${{ secrets.EMAIL_HOST_PASSWORD }}"
           --set-env-vars USE_GCLOUD_LOGGING=1
           --set-env-vars VALKEY_URL="${{ secrets.VALKEY_URL }}"
+          ${VALKEY_SERVER_CA:+--set-env-vars VALKEY_SERVER_CA="$VALKEY_SERVER_CA"}
           --allow-unauthenticated
 
   create-release:

--- a/.gitignore
+++ b/.gitignore
@@ -215,5 +215,10 @@ personal-development/
 service-account-credentials.json
 gcp-cors-config.json
 
+# Runtime-only certs (e.g. Memorystore Valkey per-instance CA).
+# Written by the deploy workflow from a GitHub environment secret;
+# must never be committed.
+runtime-certs/
+
 # npm dependencies
 node_modules/

--- a/core/middleware/rate_limit.py
+++ b/core/middleware/rate_limit.py
@@ -59,8 +59,8 @@ def _check_and_record_valkey(client, key, now_ms, limit):
         return True, None
     except redis.exceptions.RedisError as exc:
         logger.warning(
-            "rate_limiter_unavailable: failing open (exception=%s)",
-            exc.__class__.__name__,
+            "rate_limiter_unavailable: failing open exception=%s message=%s",
+            exc.__class__.__name__, exc,
         )
         return True, "valkey_unavailable"
 

--- a/core/models.py
+++ b/core/models.py
@@ -425,7 +425,15 @@ class ReferenceItem(BaseModel):
         observe = getattr(settings, "CONTENT_CACHE_OBSERVABILITY", False)
         cache_key = self._cache_key()
 
-        cached = cache.get(cache_key)
+        try:
+            cached = cache.get(cache_key)
+        except Exception as exc:
+            logger.warning(
+                "content_cache_backend_fallback cache_key=%s "
+                "operation=get exception=%s message=%s",
+                cache_key, exc.__class__.__name__, exc,
+            )
+            cached = None
         if cached is not None:
             if observe:
                 logger.info(
@@ -464,8 +472,8 @@ class ReferenceItem(BaseModel):
             # log a fallback signal if anything propagates so staging can see it
             logger.warning(
                 "content_cache_backend_fallback cache_key=%s "
-                "operation=set exception=%s",
-                cache_key, exc.__class__.__name__,
+                "operation=set exception=%s message=%s",
+                cache_key, exc.__class__.__name__, exc,
             )
 
         return content

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -1,4 +1,9 @@
+import logging
+import os
+
 from .production import *
+
+logger = logging.getLogger("schemaindex")
 
 ALLOWED_HOSTS = ['schemaindex-stg-run-799626592344.us-central1.run.app']
 PERMANENT_URL_HOST = ALLOWED_HOSTS[0]
@@ -11,6 +16,25 @@ CONTENT_CACHE_OBSERVABILITY = True
 RATE_LIMIT_OBSERVABILITY = True
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+# The deploy workflow writes the PEM (from a stg env secret) to disk and points us at it via VALKEY_SERVER_CA
+VALKEY_SERVER_CA = env.str("VALKEY_SERVER_CA", default="")
+if VALKEY_URL.startswith("rediss://") and VALKEY_SERVER_CA:
+    _ca_path = VALKEY_SERVER_CA
+    if not os.path.isabs(_ca_path):
+        _ca_path = str(BASE_DIR / _ca_path)
+    _pool_kwargs = CACHES["default"]["OPTIONS"].setdefault("CONNECTION_POOL_KWARGS", {})
+    _pool_kwargs["ssl_ca_certs"] = _ca_path
+    _pool_kwargs["ssl_cert_reqs"] = "required"
+    logger.info(
+        "Valkey TLS CA configured for staging (path=%s, exists=%s)",
+        _ca_path, os.path.exists(_ca_path),
+    )
+else:
+    logger.info(
+        "Valkey TLS CA not configured (tls=%s, ca_env_set=%s)",
+        VALKEY_URL.startswith("rediss://"), bool(VALKEY_SERVER_CA),
+    )
 
 # Update the STORAGES configuration with the staging bucket
 for key in STORAGES:


### PR DESCRIPTION
Staging's Memorystore for Valkey uses a per-instance CA, so redis-py's TLS handshake fails on every request. The rate limiter and content cache then fail open silently, producing repeated `rate_limiter_unavailable` / `content_cache_miss` logs with no visible cache hits.

This PR wires up the CA as a staging-only rollout. Production behavior is unchanged.

`staging.py` reads `VALKEY_SERVER_CA` env var and adds `ssl_ca_certs` + `ssl_cert_reqs="required"` to the inherited CACHES config. Logs whether TLS is configured at boot.

In `ci-cd.yml` I added a new step before any Django command writes the new `VALKEY_SERVER_CA_PEM` GitHub Staging environment secret to `runtime-certs/valkey/server-ca.pem` and exports `VALKEY_SERVER_CA` to `$GITHUB_ENV`. Cloud Run deploy conditionally appends `--set-env-vars VALKEY_SERVER_CA=... via ${VAR:+...}` so production deploys produce a byte-identical gcloud command.

In `rate_limit.py` and `core/models.py` I extended the failure logs and now include the exception message and `cache.get` is wrapped defensively with the same fallback log shape. Fail-open behavior preserved.

`.gitignore` /` .gcloudignore` — runtime-certs/ is git-ignored so PEMs can never be committed; re-included in the Cloud Run source build.

I also added VALKEY_SERVER_CA_PEM (raw PEM contents) as a secret in the Staging GitHub environment only.
