### PR TITLE
Add manifest export

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -208,6 +208,12 @@ class Schema(BaseModel):
                     raise PublishedSchemaConflictError(published_schema_ref, '$id')
 
     def to_manifest(self):
+        manifest = {
+            'name': self.name,
+            'public': bool(self.published_at),
+        }
+        if self.description:
+            manifest['description'] = self.description
         reference_items = (
             list(self.schemaref_set.all()) +
             list(self.documentationitem_set.all()) +
@@ -217,13 +223,9 @@ class Schema(BaseModel):
         for reference_item in reference_items:
             documents[reference_item.url] = reference_item.to_manifest_document_metadata()
 
-        manifest = {
-            'name': self.name,
-            'public': bool(self.published_at),
-            'documents': documents
-        }
-        if self.description:
-            manifest['description'] = self.description
+        # We're intentionally inserting documents last so it's the last field
+        # in the manifest when we serialize as JSON, which helps with readability.
+        manifest['documents'] = documents
     
         return manifest
 

--- a/core/models.py
+++ b/core/models.py
@@ -206,7 +206,27 @@ class Schema(BaseModel):
                     raise PublishedSchemaConflictError(published_schema_ref, 'URL')
                 if schema_ref.id_value and schema_ref.id_value == published_schema_ref.id_value:
                     raise PublishedSchemaConflictError(published_schema_ref, '$id')
-        
+
+    def to_manifest(self):
+        reference_items = (
+            list(self.schemaref_set.all()) +
+            list(self.documentationitem_set.all()) +
+            list(self.implementation_set.all())
+        )
+        documents = {}
+        for reference_item in reference_items:
+            documents[reference_item.url] = reference_item.to_manifest_document_metadata()
+
+        manifest = {
+            'name': self.name,
+            'public': bool(self.published_at),
+            'documents': documents
+        }
+        if self.description:
+            manifest['description'] = self.description
+    
+        return manifest
+
 
 class ReferenceItemManager(models.Manager):
     def get_published_by_domain_and_path(self, url):
@@ -550,6 +570,9 @@ class ReferenceItem(BaseModel):
             [recipient_email],
             fail_silently=True,
         )
+    
+    def to_manifest_document_metadata(self):
+        return { 'name': self.name } if self.name else {}
 
     @property
     def url_provider_info(self):
@@ -592,6 +615,13 @@ class SchemaRef(ReferenceItem):
 
         super().save(*args, **kwargs)
 
+    def to_manifest_document_metadata(self):
+        metadata = super().to_manifest_document_metadata()
+        return { 
+            'type': 'definition',
+            **metadata
+        }
+    
 
 class DocumentationItem(ReferenceItem):
     class DocumentationItemRole(models.TextChoices):
@@ -630,6 +660,17 @@ class DocumentationItem(ReferenceItem):
     def language(self):
         return guess_language_by_extension(self.url, ['markdown'])
 
+    def to_manifest_document_metadata(self):
+        metadata = super().to_manifest_document_metadata()
+        metadata['type'] = 'documentation'
+        if self.description:
+            metadata['description'] = self.description
+        if self.role:
+            metadata['role'] = self.role
+        if self.format:
+            metadata['format'] = self.format
+        return metadata
+
 
 class Implementation(ReferenceItem):
     is_open_source = models.BooleanField(default=False)
@@ -644,6 +685,12 @@ class Implementation(ReferenceItem):
                 'created_by': created_by
             }
         )
+
+    def to_manifest_document_metadata(self):
+        metadata = super().to_manifest_document_metadata()
+        metadata['type'] = 'implementation'
+        metadata['isOpenSource'] = self.is_open_source
+        return metadata
 
 
 class Organization(BaseModel):

--- a/core/templates/account/profile.html
+++ b/core/templates/account/profile.html
@@ -25,8 +25,11 @@ Account
           </div>
         </div>
         <div class="schema__action-group">
-          <a href="{% url 'manage_schema' schema_id=schema.pk %}">
+          <a href="{% url 'manage_schema' schema_id=schema.id %}">
             <i data-lucide="square-pen" class="icon--md"></i>
+          </a>
+          <a href="{% url 'schema_export' schema_id=schema.id %}">
+            <i data-lucide="file-braces" class="icon--md"></i>
           </a>
           {% if schema.published_at|exists_and_is_in_past %}
           <a href="{% url 'manage_schema_permanent_urls' schema_id=schema.id %}">

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -60,6 +60,15 @@ Details
     </a>
   </li>
 </ul>
+Export
+<ul class="detail-list">
+  <li class="detail-list-item__value">
+    <a href="{% url 'schema_export' schema_id=schema.id %}" class="text-with-icon">
+      Download manifest
+      <i data-lucide="file-braces" class="icon--sm"></i>
+    </a>
+  </li>
+</ul>
 <hr />
 {% endif %}
 Activity

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -60,6 +60,8 @@ Details
     </a>
   </li>
 </ul>
+{% endif %}
+<hr />
 Export
 <ul class="detail-list">
   <li class="detail-list-item__value">
@@ -69,8 +71,6 @@ Export
     </a>
   </li>
 </ul>
-<hr />
-{% endif %}
 Activity
 <ul class="detail-list">
   <li>

--- a/core/urls.py
+++ b/core/urls.py
@@ -16,6 +16,7 @@ urlpatterns = [
     path("privacy", views.privacy_policy, name="privacy_policy"),
     path("schemas/<int:schema_id>", views.schema_detail, name="schema_detail"),
     path("schemas/<int:schema_id>/definition/<int:schema_ref_id>", views.schema_ref_detail, name="schema_ref_detail"),
+    path("schemas/<int:schema_id>/export", views.schema_export, name="schema_export"),
     path("account/profile/", views.account_profile, name="account_profile"),
     path("account/api-key/", views.account_api_key, name="account_api_key"),
     path("manage/schema/<int:schema_id>", views.manage_schema, name="manage_schema"),

--- a/core/views.py
+++ b/core/views.py
@@ -8,7 +8,7 @@ from django.utils.safestring import mark_safe
 from django.contrib.auth.decorators import login_required
 from django.utils import timezone
 from django.core.exceptions import PermissionDenied
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.conf import settings
 from django.urls import reverse
 from functools import wraps
@@ -416,6 +416,19 @@ def manage_schema_permanent_urls(request, schema_id):
         'schema': schema,
         'form': form,
     })
+
+
+@lookup_schema
+def schema_export(request, schema):
+    manifest = schema.to_manifest()
+    response = JsonResponse(
+        manifest,
+        json_dumps_params={'indent': 4}
+    )
+    # Set the Content-Disposition header to attachment so the browser
+    # will actually download the file
+    response['Content-Disposition'] = f'attachment; filename="{schema.name}.json"'
+    return response
 
 
 def _permanent_url_redirect(request, permanent_url_query):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,7 +15,8 @@ from core.models import (
     Organization,
     Profile,
     PermanentURL,
-    APIKey
+    APIKey,
+    Implementation
 )
 from core.forms import PermanentURLForm
 
@@ -104,6 +105,14 @@ class DocumentationItemFactory(ReferenceItemFactory):
     schema = factory.SubFactory(SchemaFactory)
     role = factory.Iterator(DocumentationItem.DocumentationItemRole.values)
     format = factory.Iterator(DocumentationItem.DocumentationItemFormat.values)
+
+
+class ImplementationFactory(ReferenceItemFactory):
+    class Meta:
+        model = Implementation
+
+    is_open_source = factory.Faker('boolean')
+    schema = factory.SubFactory(SchemaFactory)
 
 
 class PermanentURLFactory(DjangoModelFactory):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,48 +14,7 @@ from factories import (
     UserFactory
 )
 from core.models import Schema
-
-def _assert_schema_matches_manifest(schema, manifest):
-    assert schema.name == manifest['name']
-    assert schema.description == manifest.get('description')
-    if manifest.get('public'):
-        assert schema.published_at is not None
-    else:
-        assert schema.published_at is None
-
-    manifest_definitions = []
-    manifest_documentation = []
-    manifest_implementations = []
-
-    for url, metadata in manifest['documents'].items():
-        if metadata['type'] == 'definition':
-            manifest_definitions.append(metadata | {'url': url})
-        elif metadata['type'] == 'documentation':
-            manifest_documentation.append(metadata | {'url': url})
-        elif metadata['type'] == 'implementation':
-            manifest_implementations.append(metadata | {'url': url})
-
-    assert schema.schemaref_set.count() == len(manifest_definitions)
-    for definition in manifest_definitions:
-        schema_ref = schema.schemaref_set.get(url=definition['url'])
-        assert schema_ref.name == definition.get('name')
-    
-    assert schema.documentationitem_set.count() == len(manifest_documentation)
-    for documentation in manifest_documentation:
-        documentation_item = schema.documentationitem_set.get(url=documentation['url'])
-        assert documentation_item.name == documentation['name']
-        assert documentation_item.role == documentation.get('role')
-        assert documentation_item.format == documentation.get('format')
-
-    assert schema.implementation_set.count() == len(manifest_implementations)
-    for implementation in manifest_implementations:
-        db_implementation = schema.implementation_set.get(url=implementation['url'])
-        # We want to make sure a true value is set,
-        # but we treat false and blank as the same.
-        if implementation.get('isOpenSource'):
-            assert db_implementation.is_open_source 
-        else:
-            assert not db_implementation.is_open_source
+from utils import assert_schema_matches_manifest
 
 
 def test_api_requires_key_header():
@@ -324,7 +283,7 @@ def test_create_schema_with_reference_items(api_client):
     data = response_json.get('data')
     schema_id = data.get('id')
     schema = Schema.objects.get(id=schema_id)
-    _assert_schema_matches_manifest(schema, manifest)
+    assert_schema_matches_manifest(schema, manifest)
 
 
 def test_create_rejects_non_json_payloads(api_client):
@@ -436,7 +395,7 @@ def test_update_schema(api_client):
     data = response_json.get('data')
     schema_id = data.get('id')
     schema = Schema.objects.get(id=schema_id)
-    _assert_schema_matches_manifest(schema, manifest)
+    assert_schema_matches_manifest(schema, manifest)
 
 
 @pytest.mark.django_db

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,9 +14,12 @@ from factories import (
     SchemaRefFactory,
     DocumentationItemFactory,
     ProfileFactory,
-    APIKeyFactory
+    APIKeyFactory,
+    ImplementationFactory,
+    SchemaFactory
 )
 import requests.exceptions
+from utils import assert_schema_matches_manifest
 
 
 @pytest.mark.django_db
@@ -382,4 +385,42 @@ def test_schema_ref_reparses_new_id_value_from_content_on_save():
         schema_ref.save()
         schema_ref.refresh_from_db()
         assert schema_ref.id_value == new_mock_id_value
+
+
+@pytest.mark.django_db
+def test_schema_ref_serializes_as_manifest_document_metadata():
+    schemaRef = SchemaRefFactory(name="Test Schema Ref")
+    document = schemaRef.to_manifest_document_metadata()
+    assert document['type'] == 'definition'
+    assert document['name'] == schemaRef.name
+
+
+@pytest.mark.django_db
+def test_documentation_item_serializes_as_manifest_document_metadata():
+    documentationItem = DocumentationItemFactory()
+    document = documentationItem.to_manifest_document_metadata()
+    assert document['type'] == 'documentation'
+    assert document['name'] == documentationItem.name
+    assert document['description'] == documentationItem.description
+    assert document['role'] == documentationItem.role
+    assert document['format'] == documentationItem.format
+
+
+@pytest.mark.django_db
+def test_implementation_serializes_as_manifest_document_metadata():
+    implementation = ImplementationFactory(name="Test implementation")
+    document = implementation.to_manifest_document_metadata()
+    assert document['type'] == 'implementation'
+    assert document['name'] == implementation.name
+    assert document['isOpenSource'] == implementation.is_open_source
+
+
+@pytest.mark.django_db
+def test_schema_serializes_as_manifest():
+    schema = SchemaFactory()
+    schemaRef = SchemaRefFactory(schema=schema)
+    documentationItem = DocumentationItemFactory(schema=schema)
+    implementation = ImplementationFactory(schema=schema)
+    manifest = schema.to_manifest()
+    assert_schema_matches_manifest(schema, manifest)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2,6 +2,7 @@ from urllib.parse import urlparse
 import pytest
 import requests
 import requests_mock
+import json
 from tests.factories import (
     SchemaFactory,
     UserFactory,
@@ -9,13 +10,15 @@ from tests.factories import (
     DocumentationItemFactory,
     OrganizationSchemaFactory,
     OrganizationSchemaRefFactory,
-    PermanentURLFactory
+    PermanentURLFactory,
+    ImplementationFactory
 )
 from core.models import Schema, DocumentationItem, Profile
 from core.forms import PermanentURLForm
 from django.test import Client
 from pytest_django.asserts import assertRedirects
 from unittest.mock import patch
+from utils import assert_schema_matches_manifest
 
 
 @pytest.mark.django_db
@@ -398,3 +401,17 @@ def test_schema_detail_renders_readme_on_successful_fetch():
     assert response.status_code == 200
     assert b'content-fetch-error' not in response.content
     assert b'Hello readme' in response.content
+
+
+@pytest.mark.django_db
+def test_schema_export_sends_manifest():
+    schema = SchemaFactory()
+    schemaRef = SchemaRefFactory(schema=schema)
+    documentationItem = DocumentationItemFactory(schema=schema)
+    implementation = ImplementationFactory(schema=schema)
+    client = Client()
+    response = client.get(f'/schemas/{schema.id}/export')
+    assert response.status_code == 200
+    manifest = json.loads(response.content)
+    assert_schema_matches_manifest(schema, manifest)
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,42 @@
+def assert_schema_matches_manifest(schema, manifest):
+    assert schema.name == manifest['name']
+    assert schema.description == manifest.get('description')
+    if manifest.get('public'):
+        assert schema.published_at is not None
+    else:
+        assert schema.published_at is None
+
+    manifest_definitions = []
+    manifest_documentation = []
+    manifest_implementations = []
+
+    for url, metadata in manifest['documents'].items():
+        if metadata['type'] == 'definition':
+            manifest_definitions.append(metadata | {'url': url})
+        elif metadata['type'] == 'documentation':
+            manifest_documentation.append(metadata | {'url': url})
+        elif metadata['type'] == 'implementation':
+            manifest_implementations.append(metadata | {'url': url})
+
+    assert schema.schemaref_set.count() == len(manifest_definitions)
+    for definition in manifest_definitions:
+        schema_ref = schema.schemaref_set.get(url=definition['url'])
+        assert schema_ref.name == definition.get('name')
+    
+    assert schema.documentationitem_set.count() == len(manifest_documentation)
+    for documentation in manifest_documentation:
+        documentation_item = schema.documentationitem_set.get(url=documentation['url'])
+        assert documentation_item.name == documentation['name']
+        assert documentation_item.role == documentation.get('role')
+        assert documentation_item.format == documentation.get('format')
+
+    assert schema.implementation_set.count() == len(manifest_implementations)
+    for implementation in manifest_implementations:
+        db_implementation = schema.implementation_set.get(url=implementation['url'])
+        # We want to make sure a true value is set,
+        # but we treat false and blank as the same.
+        if implementation.get('isOpenSource'):
+            assert db_implementation.is_open_source 
+        else:
+            assert not db_implementation.is_open_source
+


### PR DESCRIPTION
Closes #236.

Enables users to export schemas in the manifest format introduced in #248.

Public schemas can be exported by any user from the detail page:
<img width="367" height="836" alt="image" src="https://github.com/user-attachments/assets/e5fcd4e4-bce4-44f4-9281-fe9b172928ae" />

Users can export their own public or private schemas from the account profile page:
<img width="1010" height="406" alt="image" src="https://github.com/user-attachments/assets/50e27a16-f393-4c8d-a013-d4af8e780e24" />
(Note: The icon-only buttons are getting confusing but will be fixed with a slight redesign in #256)

Manifest downloads are named "<schema name>.json" and formatted with 4-space indents:
[Screencast From 2026-05-13 11-40-45.webm](https://github.com/user-attachments/assets/a3cfa3af-c550-4872-bd98-13217422e0e6)
