### PR TITLE
Move Valkey TLS CA plus observability to shared production settings

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -156,11 +156,7 @@ jobs:
           GCP_CREDENTIALS: ${{ secrets.GCP_CREDENTIALS }}
         run: printenv GCP_CREDENTIALS > service-account-credentials.json
 
-      - name: Write Valkey TLS CA (staging only)
-        # Memorystore for Valkey uses a per-instance CA.
-        # Stg GitHub environment defines VALKEY_SERVER_CA_PEM
-        # The production environment does not, so the `-n` guard makes this a no-op for production deploys.
-        # PEM contents are redirected straight to a file (never echoed)
+      - name: Write Valkey TLS CA
         env:
           VALKEY_SERVER_CA_PEM: ${{ secrets.VALKEY_SERVER_CA_PEM }}
         run: |

--- a/schemaindex/settings/production.py
+++ b/schemaindex/settings/production.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ImproperlyConfigured
 from google.oauth2 import service_account
 from .base import *
 
+logger = logging.getLogger("schemaindex")
+
 DEBUG = False
 PERMANENT_URL_HOST = 'id.schemas.pub'
 ALLOWED_HOSTS = [ 
@@ -49,10 +51,35 @@ CACHES = {
 
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 
-logging.getLogger("schemaindex").info(
+logger.info(
     "Valkey cache configured (tls=%s, auth=none)",
     VALKEY_URL.startswith("rediss://"),
 )
+
+# Shared Valkey TLS CA trust.
+# The deploy workflow writes the PEM to disk and points us at it via VALKEY_SERVER_CA
+VALKEY_SERVER_CA = env.str("VALKEY_SERVER_CA", default="")
+if VALKEY_URL.startswith("rediss://") and VALKEY_SERVER_CA:
+    _ca_path = VALKEY_SERVER_CA
+    if not os.path.isabs(_ca_path):
+        _ca_path = str(BASE_DIR / _ca_path)
+    _pool_kwargs = CACHES["default"]["OPTIONS"].setdefault("CONNECTION_POOL_KWARGS", {})
+    _pool_kwargs["ssl_ca_certs"] = _ca_path
+    _pool_kwargs["ssl_cert_reqs"] = "required"
+    logger.info(
+        "Valkey TLS CA configured (path=%s, exists=%s)",
+        _ca_path, os.path.exists(_ca_path),
+    )
+else:
+    logger.info(
+        "Valkey TLS CA not configured (tls=%s, ca_env_set=%s)",
+        VALKEY_URL.startswith("rediss://"), bool(VALKEY_SERVER_CA),
+    )
+
+# Observability on so we can verify Valkey behavior end-to-end.
+# TODO: Cleanup these flags and associated logging after we've verified Valkey is working well in staging/production. Upcoming PR!
+CONTENT_CACHE_OBSERVABILITY = True
+RATE_LIMIT_OBSERVABILITY = True
 
 STORAGES = {
     "default": {

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -1,9 +1,4 @@
-import logging
-import os
-
 from .production import *
-
-logger = logging.getLogger("schemaindex")
 
 ALLOWED_HOSTS = ['schemaindex-stg-run-799626592344.us-central1.run.app']
 PERMANENT_URL_HOST = ALLOWED_HOSTS[0]
@@ -11,30 +6,7 @@ SITE_URL = 'https://schemaindex-stg-run-799626592344.us-central1.run.app'
 CSRF_TRUSTED_ORIGINS = ['https://' + url for url in ALLOWED_HOSTS]
 GS_BUCKET_NAME = 'schemaindex-stg-storage'
 
-# Turn observability on in staging so we can verify Valkey behavior end-to-end
-CONTENT_CACHE_OBSERVABILITY = True
-RATE_LIMIT_OBSERVABILITY = True
-
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
-# The deploy workflow writes the PEM (from a stg env secret) to disk and points us at it via VALKEY_SERVER_CA
-VALKEY_SERVER_CA = env.str("VALKEY_SERVER_CA", default="")
-if VALKEY_URL.startswith("rediss://") and VALKEY_SERVER_CA:
-    _ca_path = VALKEY_SERVER_CA
-    if not os.path.isabs(_ca_path):
-        _ca_path = str(BASE_DIR / _ca_path)
-    _pool_kwargs = CACHES["default"]["OPTIONS"].setdefault("CONNECTION_POOL_KWARGS", {})
-    _pool_kwargs["ssl_ca_certs"] = _ca_path
-    _pool_kwargs["ssl_cert_reqs"] = "required"
-    logger.info(
-        "Valkey TLS CA configured for staging (path=%s, exists=%s)",
-        _ca_path, os.path.exists(_ca_path),
-    )
-else:
-    logger.info(
-        "Valkey TLS CA not configured (tls=%s, ca_env_set=%s)",
-        VALKEY_URL.startswith("rediss://"), bool(VALKEY_SERVER_CA),
-    )
 
 # Update the STORAGES configuration with the staging bucket
 for key in STORAGES:


### PR DESCRIPTION
Closes #258 

This PR just moves the previous Valkey observability implementation from staging to production settings plus updates ci-cd flow.
It will allow us to debug and verify that Valkey connection is working as expected on GCloud.