### PR TITLE
API documentation

### DIFF
--- a/core/api_views.py
+++ b/core/api_views.py
@@ -2,7 +2,7 @@ import json
 from functools import wraps
 from django.utils import timezone
 from django.db import transaction
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, render
 from django.conf import settings
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -101,6 +101,10 @@ def _save_manifest(manifest, schema, created_by):
         schema.published_at = timezone.now()
 
     schema.save()
+
+
+def docs(request):
+    return render(request, "core/api/docs.html")
 
 
 @require_GET

--- a/core/middleware/api_key_authentication.py
+++ b/core/middleware/api_key_authentication.py
@@ -14,7 +14,7 @@ class APIKeyAuthenticationMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if not request.path.startswith("/api/"):
+        if not request.path.startswith("/api/") or request.path == "/api/docs":
             return self.get_response(request)
 
         api_key_header = request.headers.get(API_KEY_HEADER)

--- a/core/schemas/README.md
+++ b/core/schemas/README.md
@@ -1,0 +1,126 @@
+# Schemas.Pub Manifest Schema
+
+This is a schema for a JSON manifest representing schemas for [Schemas.Pub](https://schemas.pub).
+
+## Properties
+
+A Schemas.Pub manifest is a JSON object with the following properties:
+
+| Name          | Type      | Required | Default | Description                                                                                                                                                             |
+| ------------- | --------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | `string`  | Yes      | (none)  | The schema name.                                                                                                                                                        |
+| `description` | `string`  | No       | (none)  | A brief description of the schema.                                                                                                                                      |
+| `public`      | `boolean` | No       | `false` | Controls whether the schema is publicly hosted on Schemas.Pub. **Note that once public, a schema on Schemas.Pub can't be made private except by a site administrator.** |
+| `documents`   | `object`  | Yes      | (none)  | A collection of resources related to the schema, such as definitions, documentation, and implementations.                                                               |
+
+### The `documents` object
+
+The documents object is a key-value collection where each key is a URL, and each value is an object containing metadata about the URL.
+
+Here is an example `documents` object with a schema definition file and its README:
+
+```json
+{
+  "https://example.com/schema/definition.json": {
+    "type": "definition",
+    "name": "Schema definition"
+  },
+  "https://example.com/schema/README.md": {
+    "type": "documentation",
+    "name": "README",
+    "role": "readme",
+    "format": "markdown"
+  }
+}
+```
+
+Currently, three types of URLs are supported: definitions, documentation, and implementations.
+
+#### Shared metadata properties
+
+| Name          | Type                                                                               | Required                              | Default | Description                                              |
+| ------------- | ---------------------------------------------------------------------------------- | ------------------------------------- | ------- | -------------------------------------------------------- |
+| `type`        | `string` (must be one of `"definition"`, `"documentation"`, or `"implementation"`) | Yes                                   | (none)  | The type of resource at the URL this metadata describes. |
+| `name`        | `string`                                                                           | Yes for `documentation`, otherwise no | (none)  | A name for the resource.                                 |
+| `description` | `string`                                                                           | No                                    | (none)  | A brief description of the URL.                          |
+
+#### Additional `documentation` metadata properties
+
+| Name     | Type                                                                | Required | Default | Description                                                                                             |
+| -------- | ------------------------------------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `role`   | `string` (must be one of `"readme"`, `"license"`, `"rfc"`, `"w3c"`) | No       | (none)  | Indicates what kind of documentation the resource is                                                    |
+| `format` | `string` (must be one of `"markdown"` or `"plaintext"`)             | No       | (none)  | Indicates the format of the resource content. Markdown and plaintext files are rendered on Schemas.Pub. |
+
+#### Additional `implementation` metadata properties
+
+| Name           | Type      | Required | Default | Description                                     |
+| -------------- | --------- | -------- | ------- | ----------------------------------------------- |
+| `isOpenSource` | `boolean` | No       | `false` | Indicates if the implementation is open source. |
+
+## Examples
+
+Here's a basic example manifest:
+
+```json
+{
+  "name": "Phaser Settings",
+  "description": "An open-source schema for phaser settings used by Starfleet.",
+  "public": true,
+  "documents": {
+    "https://example.com/schemas/phaser-settings/schema.json": {
+      "type": "definition",
+      "name": "Schema definition",
+      "description": "The JSON Schema specification for phaser settings"
+    },
+    "https://example.com/schemas/phaser-settings/README.md": {
+      "type": "documentation",
+      "name": "README",
+      "description": "README for the Phaser Settings schema",
+      "role": "readme",
+      "format": "markdown"
+    },
+    "https://example.com/schemas/phaser-settings/rfc.txt": {
+      "type": "documentation",
+      "name": "RFC",
+      "description": "The offical RFC for the schema",
+      "role": "rfc",
+      "format": "plaintext"
+    },
+    "https://example.com/schemas/phaser-settings/example.json": {
+      "type": "documentation",
+      "name": "Example",
+      "description": "An example of a JSON document using the phaser setting schema"
+    },
+    "https://example.com/starfleet/enterprise-phaser-settings.json": {
+      "type": "implementation",
+      "name": "Enterprise D Phaser settings",
+      "description": "The Enterprise D's current phaser settings",
+      "isOpenSource": true
+    }
+  }
+}
+```
+
+Here's a manifest for this schema itself:
+
+```json
+{
+  "name": "Schemas.Pub Manifest",
+  "description": "A manifest representing schemas for Schemas.Pub",
+  "public": true,
+  "documents": {
+    "https://raw.githubusercontent.com/dtinit/schemaindex/refs/heads/main/core/schemas/manifest.schema.json": {
+      "type": "definition",
+      "name": "Manifest Schema",
+      "description": "The definition file for the Manifest Schema"
+    },
+    "https://raw.githubusercontent.com/dtinit/schemaindex/refs/heads/main/core/schemas/README.md": {
+      "type": "documentation",
+      "name": "README",
+      "description": "The README file for the Manifest Schema",
+      "role": "readme",
+      "format": "markdown"
+    }
+  }
+}
+```

--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -639,6 +639,11 @@ a.button--primary:hover {
   padding: 2rem 0 1rem;
 }
 
+.site-footer nav {
+  display: flex;
+  gap: 1rem;
+}
+
 .badge {
   padding: 0.15rem 0.75rem;
   border-radius: 8px;
@@ -1300,4 +1305,45 @@ a.badge--w3c {
   color: var(--text-secondary);
   letter-spacing: -0.05em;
   user-select: none;
+}
+
+/* API docs page */
+.api-docs {
+  margin: 1rem auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: flex-start;
+  max-width: 60rem;
+  width: 100%;
+}
+
+.api-docs .method {
+  width: 100%;
+  background: #222;
+  padding: 1rem;
+  border-radius: 8px;
+  color: #ccc;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.api-docs .method h1,
+.api-docs .method h2,
+.api-docs .method h3,
+.api-docs .method h4 {
+  font-weight: 500;
+  color: #fff;
+}
+
+.api-docs .method h3 {
+  font-size: 18px;
+}
+
+.api-docs code pre {
+  background: #000;
+  border-radius: 8px;
+  padding: 1rem;
 }

--- a/core/templates/account/api_key.html
+++ b/core/templates/account/api_key.html
@@ -13,7 +13,7 @@ API Key
     <input readonly value="{{ new_api_key }}" />
     This API key will not be shown again, but you can replace it with a new key later. Please treat it as you would a password.
     {% else %}
-    <p>Create an API key to use with the Schemas.Pub API.</p>
+    <p>Create an API key to use with the <a href="{% url 'api_docs' %}">Schemas.Pub API</a>.</p>
     {% if request.user.profile.api_key %}
     <p>Warning: Creating a new API key will invalidate your previous key created on {{ request.user.profile.api_key.created_at|date }}.</p>
     {% endif %}

--- a/core/templates/core/api/docs.html
+++ b/core/templates/core/api/docs.html
@@ -1,0 +1,112 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+Schemas.Pub - API Documentation
+{% endblock %}
+
+{% block page_content %}
+<main class="api-docs">
+  <h1>API Documentation</h1>
+  <h2>Authentication</h2>
+  <p>
+    All API methods require an X-API-Key header with an API key.
+  {% if request.user %}
+  You can create an API key <a href="{% url 'account_api_key' %}">here</a>.
+  {% else %}
+  <a href="{ url 'account_signup'}">Create an account</a> to get an API key.
+  {% endif %}
+  </p>
+  <h2>Methods</h2>
+  <section class="method">
+    <h3>GET /api/find?id=[$id]</h3>
+    <p>Looks up a JSON schema by its $id value.</p>
+    <h4>Parameters</h4>
+    <ul>
+      <li><b>id</b>: The $id value of a JSON schema</li>
+    </ul>
+    <h4>Response</h4>
+    <p>A JSON object containing a "data" object with the following property:</p>
+    <ul>
+      <li><b>url</b>: A URL to the matching definition file</li>
+    </ul>
+    <code>
+      <pre>
+{
+  "data": {
+    "url": "https://example.com/schema.json"
+  }
+}</pre>
+    </code>
+    <h4>Response</h4>
+    <p>A JSON object containing a "data" object with the following proprties:</p>
+    <ul>
+      <li><b>id</b>: The created schema's ID</li>
+      <li><b>url</b>: A URL for the schema on Schemas.Pub</li>
+    </ul>
+    <code>
+      <pre>
+{
+  "data": {
+    "url": "https://schemas.pub/schemas/30/definition/341"
+  }
+}</pre>
+    </code>
+
+  </section>
+  <section class="method">
+    <h3>POST /api/schema/create</h3>
+    <p>Creates a new schema.</p>
+    <h4>Body</h4>
+    <p>
+      The body of your request should be a <a href="https://schemas.pub/schemas/30">Schemas.Pub manifest</a>.
+    </p>
+    <h4>Response</h4>
+    <p>A JSON object containing a "data" object with the following proprties:</p>
+    <ul>
+      <li><b>id</b>: The schema's ID</li>
+      <li><b>url</b>: A URL for the schema on Schemas.Pub</li>
+    </ul>
+    <code>
+      <pre>
+{
+  "data": {
+    "id": 30,
+    "url": "https://schemas.pub/schemas/30"
+  }
+}</pre>
+    </code>
+  </section>
+  <section class="method">
+    <h3>PUT /api/schema/[schema_id]</h3>
+    <p>Updates the specified schema.</p>
+    <h4>Body</h4>
+    <p>
+      The body of your request should be a <a href="https://schemas.pub/schemas/30">Schemas.Pub manifest</a>.
+    </p>
+    <h4>Response</h4>
+    <p>A JSON object containing a "data" object with the following proprties:</p>
+    <ul>
+      <li><b>id</b>: The schema's ID</li>
+      <li><b>url</b>: A URL for the schema on Schemas.Pub</li>
+    </ul>
+    <code>
+      <pre>
+{
+  "data": {
+    "id": 30,
+    "url": "https://schemas.pub/schemas/30"
+  }
+}</pre>
+    </code>
+
+  </section>
+  <h2>Errors</h2>
+  <p>
+    Error responses will be a JSON object containing an "error": object with the following properties:
+    <ul>
+      <li><b>code</b>: A status code for the error</li>
+      <li><b>message</b>: An error message</li>
+      <li><b>details</b>: (Optional) Additional information about the message</li>
+    </ul>
+  </p>
+ </main>
+{% endblock %}

--- a/core/templates/core/partials/footer.html
+++ b/core/templates/core/partials/footer.html
@@ -1,10 +1,12 @@
 <footer class="site-footer">
-  <div>
-    <a href="/about">About</a>&nbsp;&nbsp;
+  <nav>
+    <a href="/about">About</a>
     <a href="https://docs.google.com/forms/d/1yPMuDri2VLWdv0WW6gj_GPA7xOSg-Nqc7_nfTJmabQg"
-    >Contact</a>&nbsp;&nbsp;
-    <a href="{% url 'terms_of_use' %}">Terms of Use</a>&nbsp;&nbsp;
-    <a href="{% url 'privacy_policy' %}">Privacy Policy</a></div>
+    >Contact</a>
+    <a href="{% url 'terms_of_use' %}">Terms of Use</a>
+    <a href="{% url 'privacy_policy' %}">Privacy Policy</a>
+    <a href="{% url 'api_docs' %}">API</a>
+  </nav>
   <div>&copy; {% now "Y" %} <a href="https://dtinit.org">Data Transfer
     Initiative.</a></div>
 </footer>

--- a/core/urls.py
+++ b/core/urls.py
@@ -4,6 +4,7 @@ from . import views
 from . import api_views
 
 api_endpoints = [
+    path("docs", api_views.docs, name="api_docs"),
     path("find", api_views.find, name="api_find"),
     path("schemas", api_views.schemas_create, name="api_schemas_create"),
     path(


### PR DESCRIPTION
Closes #241.

Adds basic documentation for the API. I also added the manifest schema to the site itself (https://schemas.pub/schemas/30) which is referenced in this documentation. Links to the documentation are in the site footer and on the API key management page.

<img width="1278" height="1323" alt="image" src="https://github.com/user-attachments/assets/215573a9-ff2e-485a-9d4f-906201b641c2" />

