### PR TITLE
Hide Permanent URL section for private schemas

### DIFF
--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -82,7 +82,7 @@ Activity
     <div class="detail-list-item__value">{{ schema.created_at|date }}</div>
   </li>
 </ul>
-{% if schema.permanent_urls.count > 0 or schema.created_by == request.user %}
+{% if schema.permanent_urls.count > 0 or schema.created_by == request.user and schema.published_at|exists_and_is_in_past %}
 Permanent URLs
 <ul class="detail-list">
   {% for permanent_url in schema.permanent_urls.all|dictsort:"url" %}  

--- a/core/templates/core/schemas/detail_schema_ref.html
+++ b/core/templates/core/schemas/detail_schema_ref.html
@@ -50,7 +50,7 @@ Activity
     <div class="detail-list-item__value">{{ schema_ref.created_at|date }}</div>
   </li>
 </ul>
-{% if schema_ref.permanent_urls.count > 0 or schema_ref.created_by == request.user %}
+{% if schema_ref.permanent_urls.count > 0 or schema_ref.created_by == request.user and schema.published_at|exists_and_is_in_past %}
 Permanent URL{{ schema_ref.permanent_urls.count|pluralize }}
 <ul class="detail-list">
   {% for permanent_url in schema_ref.permanent_urls.all|dictsort:"url" %}  


### PR DESCRIPTION
Closes #262.

We don't support adding permanent URLs for private schemas so we shouldn't show the section when a user is looking at one.