### PR TITLE
Add overridable `published_at` change prevention for Schemas

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -35,6 +35,11 @@ class SchemaAdmin(admin.ModelAdmin):
     def formatted_is_published(self, obj):
         return "✓" if obj.is_published else ""
 
+    def save_model(self, request, obj, form, change):
+        # Passing this flag allows us to
+        # override custom validation
+        obj.save(is_admin_change=True)
+
 
 @register(SchemaRef)
 class SchemaRefAdmin(admin.ModelAdmin):

--- a/core/api_views.py
+++ b/core/api_views.py
@@ -49,7 +49,7 @@ def _save_manifest(manifest, schema, created_by):
     schema.description = manifest.get("description")
     public = manifest.get("public") or False
 
-    # Prevent users from making public schemas private
+    # Warn users when attempting to make public schemas private
     if not public and schema.published_at:
         raise DjangoValidationError(
             "Public schemas cannot be made private except by an admin. Please set `public: true` in your manifest."

--- a/core/models.py
+++ b/core/models.py
@@ -8,6 +8,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelatio
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.hashers import make_password, check_password
 from django.core.cache import cache
+from django.core.exceptions import ValidationError
 from urllib.parse import urlparse
 import time
 import requests
@@ -120,6 +121,19 @@ class Schema(BaseModel):
 
     def __str__(self):
         return self.name
+
+    def save(self, *args, is_admin_change=False, **kwargs):
+        # Validate published_at if the object already exists,
+        # unless an admin is making the change.
+        if self.id and not is_admin_change:
+            original = Schema.objects.get(id=self.id)
+
+            if original.published_at and original.published_at != self.published_at:
+                raise ValidationError(
+                    "A public schema cannot have its visibility changed except by an administrator."
+                )
+
+        super().save(*args, **kwargs)
 
     @property
     def is_published(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,6 @@ def test_api_key_allows_valid_api_key(api_client):
     with requests_mock.Mocker() as m:
         m.get(url, text=content)
         schema_ref = SchemaRefFactory.create(url=url)
-        schema_ref.save()
         schema_ref.refresh_from_db()
         response = api_client.get(f"/api/find?id={id_value}")
         assert response.status_code == 200
@@ -103,11 +102,10 @@ def test_find_returns_404s_for_matching_private_schemas(api_client):
     url = "https://example.com/schema.json"
     id_value = "https://example.com/testid"
     content = f'{{"$id":"{id_value}"}}'
+    private_schema = SchemaFactory.create(published_at=None)
     with requests_mock.Mocker() as m:
         m.get(url, text=content)
-        schema_ref = SchemaRefFactory.create(url=url)
-        schema_ref.schema.published_at = None
-        schema_ref.schema.save()
+        SchemaRefFactory.create(url=url, schema=private_schema)
         response = api_client.get(
             f"/api/find?id={id_value}",
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from django.core.cache import cache
 from django.utils import timezone
 from django.core import mail
 from django.contrib.auth.hashers import make_password
+from django.core.exceptions import ValidationError
 from core.models import Schema, SchemaRef, APIKey
 from factories import (
     UserFactory,
@@ -395,3 +396,48 @@ def test_schema_serializes_as_manifest():
     ImplementationFactory(schema=schema)
     manifest = schema.to_manifest()
     assert_schema_matches_manifest(schema, manifest)
+
+
+@pytest.mark.django_db
+def test_schema_published_at_cannot_be_unset():
+    schema = SchemaFactory.create()
+    schema.published_at = None
+    with pytest.raises(ValidationError):
+        schema.save()
+
+
+@pytest.mark.django_db
+def test_schema_published_at_cannot_be_changed():
+    schema = SchemaFactory.create()
+    schema.published_at = timezone.now()
+    with pytest.raises(ValidationError):
+        schema.save()
+
+
+@pytest.mark.django_db
+def test_schema_published_at_can_be_set_first_time():
+    schema = SchemaFactory.create(published_at=None)
+    published_at_value = timezone.now()
+    schema.published_at = published_at_value
+    schema.save()
+    schema.refresh_from_db()
+    assert schema.published_at == published_at_value
+
+
+@pytest.mark.django_db
+def test_schema_published_at_can_be_unset_by_admins():
+    schema = SchemaFactory.create()
+    schema.published_at = None
+    schema.save(is_admin_change=True)
+    schema.refresh_from_db()
+    assert schema.published_at is None
+
+
+@pytest.mark.django_db
+def test_schema_published_at_can_be_changed_by_admins():
+    schema = SchemaFactory.create()
+    published_at_value = timezone.now()
+    schema.published_at = published_at_value
+    schema.save(is_admin_change=True)
+    schema.refresh_from_db()
+    assert schema.published_at == published_at_value


### PR DESCRIPTION
Closes #251.

Prevents `Schema.published_at` from being changed once it's set. This can be overridden from the admin panel:

[Screencast From 2026-05-27 12-09-49.webm](https://github.com/user-attachments/assets/a7f3b370-5a20-4498-8736-5cf95e77b4cd)

Note that it is still the responsibility of callers of `Schema.save` to make sure they don't attempt to change `published_at`. I was worried that having `.save()` silently ignore attempts to change `published_at` could be unexpected. The downside is this means we can't actually reduce any code from #248 which is what prompted this issue.