### PR TITLE
Exempt API views from CSRF checks

### DIFF
--- a/core/api_views.py
+++ b/core/api_views.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.shortcuts import get_object_or_404, render
 from django.conf import settings
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
+from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.urls import reverse
 from jsonschema import validate, ValidationError as JSONValidationError
@@ -120,6 +121,7 @@ def find(request):
 @require_POST
 @require_manifest
 @transaction.atomic
+@csrf_exempt
 def schemas_create(request, manifest):
     schema = Schema(created_by=request.user)
     try:
@@ -141,6 +143,7 @@ def schemas_create(request, manifest):
 @require_manifest
 @lookup_schema
 @transaction.atomic
+@csrf_exempt
 def schemas_update(request, manifest, schema):
     if schema.created_by != request.user:
         return ApiErrorResponse(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.cache import cache
+from django.test import Client
 import requests_mock as requests_mock_lib
 from factories import ProfileFactory
 
@@ -30,9 +31,19 @@ def fallback_get_request_mock(requests_mock):
 
 
 @pytest.fixture
-def api_client(client, db):
+def api_client(db):
     profile = ProfileFactory.create()
     api_key = profile.set_new_api_key()
+    # Django requires CSRF tokens for "unsafe" HTTP methods
+    # (POST/PUT/DELETE/etc) by default. To help verify that
+    # our API views are exempt from CSRF checks as intended,
+    # here we enable CSRF checks in the Django test client
+    # used for API testing. Any API tests which use this
+    # test client to test an API view that isn't exempt from CSRF
+    # will fail, alerting developers of the problem.
+    # Use the @csrf_exempt decorator for API views with "unsafe"
+    # HTTP methods.
+    client = Client(enforce_csrf_checks=True)
     client.defaults["HTTP_X_API_KEY"] = api_key
     client.user = profile.user
     return client


### PR DESCRIPTION
The create and update API views introduced in #248 worked in unit testing but not in practice because Django automatically requires CSRF tokens for PUT and POST requests *except* in testing. This PR exempts those views from CSRF checks and updates our unit tests to hopefully catch future API views which aren't exempt from CSRF.