### PR TITLE
Add secure_proxy_ssl_header to Prod setting

### DIFF
--- a/schemaindex/settings/production.py
+++ b/schemaindex/settings/production.py
@@ -77,6 +77,7 @@ STORAGES = {
 
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 if os.environ.get("USE_GCLOUD_LOGGING", "0") == "1":
     LOGGING["handlers"]["cloud_logging"] = {

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -6,8 +6,6 @@ SITE_URL = "https://schemaindex-stg-run-799626592344.us-central1.run.app"
 CSRF_TRUSTED_ORIGINS = ["https://" + url for url in ALLOWED_HOSTS]
 GS_BUCKET_NAME = "schemaindex-stg-storage"
 
-SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
-
 # Reset to the base default
 CONTENT_CACHE_TTL = 60 * 60
 


### PR DESCRIPTION
Closes #272 

Few small things that I thought could be improved or needed attention.

First, while working on Valkey setup I realized that `SECURE_PROXY_SSL_HEADER` is only present on staging.

Clod Run terminates TLS at its proxy layer and then forwards plain HTTP to our container. So then Django's `request.is_secure()` looks at the scheme of the incoming request, which is now http, and returns `False`.

Cloud Run sets `X-Forwarded-Proto: https` on the forwarded request, and `SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')` tells Django to trust that header when determining `is_secure()`.

---

The second thing is that each time we run the test suite we get a `FORMS_URLFIELD_ASSUME_HTTPS` deprecation warning.

I knew we could avoid having this warning but I came to the conclusion that is better if we just wait to upgrade to Django 6.0, where "https" becomes the built-in default and the transitional settings is just removed.

---

And lastly, I received a GCloud email alert about some CA certificate action needed due to some changes soon to be implemented but after some research I found out that this doesn't affect us so we're good. No changes needed.