### PR TITLE
User profile schema list design iteration

### DIFF
--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -1070,51 +1070,86 @@ a.badge--w3c {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
   width: 100%;
+  border: 1px solid #444;
+  border-radius: 6px;
 }
 
 .account .schema-list .schema {
   width: 100%;
-  padding: 0.5rem 1rem;
-  background: #333;
-  border-radius: 8px;
+  padding: 1rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  border-bottom: 1px solid #444;
 }
 
-.account .schema-list .schema .schema__action-group,
+.account .schema-list .schema:last-child {
+  border-bottom: none;
+}
+
 .account .schema-list .schema .schema__info {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.5rem;
+}
+
+.account .schema-list .schema .schema__info .schema__badges {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.account .schema-list .schema .schema__action-group {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.account .schema-list .schema .schema__action-group .action-button {
+  font-size: 14px;
+  border-radius: 6px;
+  border: 1px solid #444;
+  padding: 0.15rem 0.5rem;
+  color: #ccc;
+  background: #222;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+}
+
+.account .schema-list .schema .schema__action-group .action-button:hover {
+  background: #333;
+}
+
+.account .schema-list .schema .schema__action-group .action-button--danger {
+  color: var(--danger-color-text);
+}
+
+.account
+  .schema-list
+  .schema
+  .schema__action-group
+  .action-button--danger:hover {
+  background: var(--danger-color-highlight);
+  border-color: var(--danger-color);
+  color: #fff;
 }
 
 .account .visibility-badge {
   display: inline-block;
-  padding: 0.15rem 0.75rem;
-  padding: 0.15rem 0.75rem;
-  border-radius: 1rem;
-  font-size: 14px;
-}
-
-.account .visibility-badge--published {
-  background: var(--primary-color);
-  color: #eee;
-}
-
-.account .visibility-badge--unpublished {
-  background: #525252;
-  color: #ddd;
-}
-
-.account .schema-list .schema .info {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
+  padding: 0.15rem 0.5rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 6px;
+  font-size: 12px;
+  border: 1px solid #444;
+  color: #aaa;
 }
 
 /* API Key page */

--- a/core/templates/account/profile.html
+++ b/core/templates/account/profile.html
@@ -59,6 +59,10 @@ Account
           <a href="{% url 'manage_schema_permanent_urls' schema_id=schema.id %}" class="action-button">
             <i data-lucide="link" class="icon--sm"></i> Manage URLs
           </a>
+          {% else %}
+          <a href="{% url 'manage_schema_publish' schema_id=schema.id %}" class="action-button">
+            <i data-lucide="eye" class="icon--sm"></i> Make public
+          </a>
           {% endif %}
           {% if not schema.published_at|exists_and_is_in_past %}
           <a href="{% url 'manage_schema_delete' schema_id=schema.id %}" class="action-button action-button--danger">

--- a/core/templates/account/profile.html
+++ b/core/templates/account/profile.html
@@ -13,7 +13,31 @@ Account
       {% for schema in user_schemas|dictsort:"name" %}
       <li class="schema">
         <div class="schema__info">
-          <a href="{% url 'schema_detail' schema_id=schema.id %}">{{schema.name}}</a>
+          <div>
+            <a href="{% url 'schema_detail' schema_id=schema.id %}">{{schema.name}}</a>
+            <ul class="schema__badges">
+              {% if schema.latest_rfc %}
+              <li class="badge badge--rfc" title="Linked RFC">
+                RFC
+              </li>
+              {% endif %}
+              {% if schema.latest_w3c %}
+              <li class="badge badge--w3c" title="Linked W3C specification">
+                W3C
+              </li>
+              {% endif %}
+              {% if schema.implementation_set.count %}
+              <li title="Linked {% if schema.has_open_source_implementation %}open source {% endif %}implementations" class="badge--implementations">
+                <i
+                  data-lucide="layers-2"
+                  class="icon--sm
+                    {% if schema.has_open_source_implementation%}implementation-icon--open-source{% endif %}
+                "
+                ></i>
+              </li>
+              {% endif %}
+            </ul>
+          </div>
           {% if schema.published_at|exists_and_is_in_past %}
           <div class="visibility-badge visibility-badge--published">
           Public
@@ -25,20 +49,20 @@ Account
           </div>
         </div>
         <div class="schema__action-group">
-          <a href="{% url 'manage_schema' schema_id=schema.id %}">
-            <i data-lucide="square-pen" class="icon--md"></i>
+          <a href="{% url 'manage_schema' schema_id=schema.id %}" class="action-button">
+            <i data-lucide="square-pen" class="icon--sm"></i> Edit
           </a>
-          <a href="{% url 'schema_export' schema_id=schema.id %}">
-            <i data-lucide="file-braces" class="icon--md"></i>
+          <a href="{% url 'schema_export' schema_id=schema.id %}" class="action-button">
+            <i data-lucide="file-braces" class="icon--sm"></i> Export
           </a>
           {% if schema.published_at|exists_and_is_in_past %}
-          <a href="{% url 'manage_schema_permanent_urls' schema_id=schema.id %}">
-            <i data-lucide="link" class="icon--md"></i>
+          <a href="{% url 'manage_schema_permanent_urls' schema_id=schema.id %}" class="action-button">
+            <i data-lucide="link" class="icon--sm"></i> Manage URLs
           </a>
           {% endif %}
           {% if not schema.published_at|exists_and_is_in_past %}
-          <a href="{% url 'manage_schema_delete' schema_id=schema.id %}">
-            <i data-lucide="trash" class="icon--md"></i>
+          <a href="{% url 'manage_schema_delete' schema_id=schema.id %}" class="action-button action-button--danger">
+            <i data-lucide="trash" class="icon--sm"></i> Delete
           </a>
           {% endif %}
         </div>


### PR DESCRIPTION
Closes #256.

Redesigns the schema list on a user's profile page to clarify what each of the buttons do, add a "make public" button, add the reputational badges we use in other places, and change the visibility labels so they don't look too similar to our reputational badges.

<img width="1284" height="1011" alt="image" src="https://github.com/user-attachments/assets/32eb5180-148f-4ff1-9ffc-9e674c2b204b" />

