### PR TITLE
Default to organization link type when user belongs to an org

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -391,21 +391,22 @@ class PermanentURLForm(forms.Form):
             ))
         self.fields["target"].choices = target_choices
 
-        link_type_choices = [
-            (self.LinkType.UUID, "schemas.pub/u/"),
-            (self.LinkType.EMAIL, f"schemas.pub/e/{schema.created_by.email}/"),
-        ]
-        # Only users in an org can create org URLs
+        link_type_choices = []
+        # Only users in an org can create org URLs; org is the default when available
         if schema.created_by.profile.organization:
             link_type_choices.append((
                 self.LinkType.ORGANIZATION,
                 f"schemas.pub/o/{schema.created_by.profile.organization.slug}/",
             ))
+        link_type_choices += [
+            (self.LinkType.UUID, "schemas.pub/u/"),
+            (self.LinkType.EMAIL, f"schemas.pub/e/{schema.created_by.email}/"),
+        ]
         self.fields["link_type"].choices = link_type_choices
 
         link_type = self.data.get("link_type") or self.initial.get("link_type")
         if link_type not in (choice[0] for choice in link_type_choices):
-            link_type = self.LinkType.UUID
+            link_type = link_type_choices[0][0]
         # When creating a UUID, change the suffix field to an uneditable placeholder.
         # We'll generate a UUID on submission.
         if link_type == self.LinkType.UUID:


### PR DESCRIPTION
In the GUI dropdown we were defaulting to the /u/ URL type, and I think when a user belongs to an org they would likely default to the /o/ URL type.
<img width="1097" height="489" alt="Screenshot 2026-06-08 at 12 47 17 PM" src="https://github.com/user-attachments/assets/cc25509c-fd9a-488a-94ad-9d44faf22e88" />

