### PR TITLE
Prevent concurrent GH Actions deployments

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -205,6 +205,13 @@ jobs:
       - check-pending-migrations
       - test-python
       - check-python-formatting
+    # Prevent parallel workflow runs from deploying to the same environment at the same time.
+    concurrency:
+      # Separate by environment so staging deployments don't interrupt production and vice versa. 
+      group: deploy_${{ inputs.environment || 'Staging' }}
+      # Just to be safe, allow in-progress production deployments to fully complete
+      # before starting another one.
+      cancel-in-progress: ${{ inputs.environment != 'Production' }}
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment || 'Staging' }}


### PR DESCRIPTION
Closes #277.

Prevent parallel GitHub Actions from deploying to the same environment at the same time, which can cause issues. This can happen if multiple PRs are merged to main at the same time causing multiple deployment attempts to staging.

The behavior is a little different depending on the environment. In staging, in-progress deployments will be cancelled in favor of newer deployment jobs. In production (which is not likely to experience parallel deployments anyway), in-progress deployments are allowed to complete, and the latest of any further deployment jobs are queued until the first job completes. For example:
1. Job 1 starts deploying
2. Job 2 queues for later since job 1 is in progress
3. Job 3 queues for later (and *replaces* job 2 in the queue) since job 1 is in progress
4. Job 1: finishes
5. Job **3**: starts deploying