### PR TITLE
Ensure the find method of the API ignores case

### DIFF
--- a/core/api_views.py
+++ b/core/api_views.py
@@ -114,7 +114,7 @@ def find(request):
     published_schema_refs = SchemaRef.objects.filter(
         schema__in=Schema.public_objects.all()
     )
-    schema_ref = get_object_or_404(published_schema_refs, id_value=id_value)
+    schema_ref = get_object_or_404(published_schema_refs, id_value__iexact=id_value)
     return ApiResponse({"url": schema_ref.url})
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,24 @@ def test_find_returns_404s_for_matching_private_schemas(api_client):
 
 
 @pytest.mark.django_db
+def test_find_ignores_case(api_client):
+    url = "https://example.com/schema.json"
+    id_value = "https://example.com/testid"
+    content = f'{{"$id":"{id_value}"}}'
+    with requests_mock.Mocker() as m:
+        m.get(url, text=content)
+        SchemaRefFactory.create(url=url)
+        response = api_client.get(
+            f"/api/find?id={id_value.upper()}",
+        )
+        assert response.status_code == 200
+        response_json = response.json()
+        data = response_json.get("data")
+        url = data.get("url")
+        assert url == url
+
+
+@pytest.mark.django_db
 @override_settings(HOURLY_API_REQUEST_LIMIT=1)
 def test_rate_limit_is_isolated_per_profile():
     # One profile hitting its limit must not affect a different profile.


### PR DESCRIPTION
Closes #275.

Small change to ensure the find method ignores case when comparing `$id`s, plus a test to verify.