### PR TITLE
Initial MCP support (feature flagged)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy local code to the container image.
 COPY . .
 
-CMD exec gunicorn --capture-output --bind 0.0.0.0:$PORT --workers 1 --threads 8 --timeout 0 schemaindex.wsgi
+CMD exec gunicorn --capture-output --bind 0.0.0.0:$PORT --workers 1 -k uvicorn.workers.UvicornWorker --timeout 0 schemaindex.asgi:application

--- a/core/mcp.py
+++ b/core/mcp.py
@@ -1,0 +1,67 @@
+import json
+from django.db.models import Q
+from django.utils import timezone
+from django.conf import settings
+from mcp.server.fastmcp import FastMCP
+from core.models import Schema
+from asgiref.sync import sync_to_async
+
+mcp = FastMCP(
+    "Schemas.Pub", stateless_http=True, json_response=True, streamable_http_path="/"
+)
+
+
+def format_schema(schema):
+    formatted_schema = f"""
+Name: {schema.name}
+ID: {schema.id}
+"""
+    if schema.description:
+        formatted_schema += f"""Description: {schema.description}
+"""
+    return formatted_schema
+
+
+# TODO: This will need to be paginated
+@mcp.tool()
+@sync_to_async
+def list_schemas():
+    """List all available schemas."""
+    public_schemas = [format_schema(schema) for schema in Schema.public_objects.all()]
+    return "\n---\n".join(public_schemas)
+
+
+@mcp.resource("schema://manifest.json")
+async def get_manifest_schema():
+    """Get the Schemas.Pub manifest schema"""
+    # TODO: dedupe from api_views.py
+    schema_path = settings.BASE_DIR / "core" / "schemas" / "manifest.schema.json"
+    with open(schema_path, "r") as f:
+        return f.read()
+
+
+@mcp.resource("schema://{schema_id}")
+async def get_schema(schema_id):
+    """Get a schema's manifest"""
+
+    @sync_to_async
+    def fetch_from_db():
+        # TODO: dedupe from core.views:lookup_schema
+        schema_filter = Q(published_at__lte=timezone.now())
+
+        # TODO: get the user from the API key
+        # if request.user.is_authenticated:
+        #    schema_filter |= Q(created_by=request.user)
+
+        schema = (
+            Schema.objects
+            .prefetch_related("schemaref_set")
+            .prefetch_related("documentationitem_set")
+            .filter(schema_filter)
+            .get(pk=schema_id)
+        )
+        return schema.to_manifest()
+
+    # Await the sync-to-async execution
+    manifest = await fetch_from_db()
+    return json.dumps(manifest, indent=2)

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,12 @@ def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings.development")
 
-    # Intercept runserver so we can use an ASGI server
+    # Intercept runserver so we can use an ASGI server.
+    #
+    # Django supports Daphne natively, but at time of writing,
+    # Daphne doesn't support the lifespan protocol, which is required by our MCP server.
+    # See https://github.com/django/daphne/issues/264
+    # and https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/daphne/
     if len(sys.argv) > 1 and sys.argv[1] == "runserver":
         import uvicorn
 

--- a/manage.py
+++ b/manage.py
@@ -8,6 +8,35 @@ import sys
 def main():
     """Run administrative tasks."""
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings.development")
+
+    # Intercept runserver so we can use an ASGI server
+    if len(sys.argv) > 1 and sys.argv[1] == "runserver":
+        import uvicorn
+
+        # Default to port 8000, but allow overrides like `python manage.py runserver 8080`
+        port = 8000
+        if len(sys.argv) > 2:
+            try:
+                # Handle basic port passing
+                port_arg = sys.argv[2]
+                port = (
+                    int(port_arg.split(":")[-1]) if ":" in port_arg else int(port_arg)
+                )
+            except ValueError:
+                pass
+
+        print(f"Starting Uvicorn development server at http://127.0.0.1:{port}/")
+        print("Quit the server with CONTROL-C.")
+
+        # We pass the app as an import string so uvicorn's auto-reload works
+        uvicorn.run(
+            "schemaindex.asgi:application",
+            host="127.0.0.1",
+            port=port,
+            reload=True,
+        )
+        return
+
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ isoduration==20.11.0
 jsonpointer==3.1.1
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
+mcp==1.27.2
 opentelemetry-api==1.37.0
 packaging==25.0
 pillow==12.1.1
@@ -64,6 +65,7 @@ sqlparse==0.5.3
 typing_extensions==4.15.0
 uri-template==1.3.0
 urllib3==2.5.0
+uvicorn[standard]==0.49.0
 webcolors==25.10.0
 webencodings==0.5.1
 zipp==3.23.0

--- a/schemaindex/asgi.py
+++ b/schemaindex/asgi.py
@@ -15,32 +15,41 @@ from starlette.applications import Starlette
 from starlette.routing import Mount
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings.development")
-django_app = get_asgi_application()
-
-# Serve static files in development
-if settings.DEBUG:
-    from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
-
-    django_app = ASGIStaticFilesHandler(django_app)
-
-# This must come *after* initializing Django
-from core.mcp import mcp  # noqa: E402
 
 
-# Create a lifespan context manager to run the session manager
-@contextlib.asynccontextmanager
-async def lifespan(app: Starlette):
-    async with mcp.session_manager.run():
-        yield
+def create_application():
+    django_app = get_asgi_application()
+
+    # Serve static files in development
+    if settings.DEBUG:
+        from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+
+        django_app = ASGIStaticFilesHandler(django_app)
+
+    if not settings.ENABLE_MCP_SERVER:
+        return django_app
+
+    # This must come after initializing Django
+    from core.mcp import mcp  # noqa: E402
+
+    # Create a lifespan context manager to run the session manager
+    @contextlib.asynccontextmanager
+    async def lifespan(app: Starlette):
+        async with mcp.session_manager.run():
+            yield
+
+    # Use Starlette (which is bundled with mcp)
+    # to route /mcp requests to the mcp server,
+    # and anything else to Django
+    application = Starlette(
+        routes=[
+            Mount("/mcp", app=mcp.streamable_http_app()),
+            Mount("/", app=django_app),
+        ],
+        lifespan=lifespan,
+    )
+
+    return application
 
 
-# Use Starlette (which is bundled with mcp)
-# to route /mcp requests to the mcp server,
-# and anything else to Django
-application = Starlette(
-    routes=[
-        Mount("/mcp", app=mcp.streamable_http_app()),
-        Mount("/", app=django_app),
-    ],
-    lifespan=lifespan,
-)
+application = create_application()

--- a/schemaindex/asgi.py
+++ b/schemaindex/asgi.py
@@ -33,6 +33,8 @@ def create_application():
     from core.mcp import mcp  # noqa: E402
 
     # Create a lifespan context manager to run the session manager
+    # At time of writing, MCP requires the lifespan protocol but Daphne doesn't support it,
+    # which is why we must use uvicorn.
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette):
         async with mcp.session_manager.run():

--- a/schemaindex/asgi.py
+++ b/schemaindex/asgi.py
@@ -7,10 +7,40 @@ For more information on this file, see
 https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 """
 
+import contextlib
 import os
-
 from django.core.asgi import get_asgi_application
+from django.conf import settings
+from starlette.applications import Starlette
+from starlette.routing import Mount
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings.development")
+django_app = get_asgi_application()
 
-application = get_asgi_application()
+# Serve static files in development
+if settings.DEBUG:
+    from django.contrib.staticfiles.handlers import ASGIStaticFilesHandler
+
+    django_app = ASGIStaticFilesHandler(django_app)
+
+# This must come *after* initializing Django
+from core.mcp import mcp  # noqa: E402
+
+
+# Create a lifespan context manager to run the session manager
+@contextlib.asynccontextmanager
+async def lifespan(app: Starlette):
+    async with mcp.session_manager.run():
+        yield
+
+
+# Use Starlette (which is bundled with mcp)
+# to route /mcp requests to the mcp server,
+# and anything else to Django
+application = Starlette(
+    routes=[
+        Mount("/mcp", app=mcp.streamable_http_app()),
+        Mount("/", app=django_app),
+    ],
+    lifespan=lifespan,
+)

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -187,3 +187,6 @@ MEDIA_URL = "/media/"
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 
 HOURLY_API_REQUEST_LIMIT = 500
+
+# Feature flags
+ENABLE_MCP_SERVER = False

--- a/schemaindex/settings/development.py
+++ b/schemaindex/settings/development.py
@@ -4,3 +4,4 @@ DEBUG = True
 ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 PERMANENT_URL_HOST = "localhost"
 SITE_URL = "http://localhost:8000"
+ENABLE_MCP_SERVER = True


### PR DESCRIPTION
Closes #278.

Adds very basic MCP server support behind a feature flag that's disabled in all environments but development.

MCP support is facilitated with the [official Python SDK](https://github.com/modelcontextprotocol/python-sdk).

Because the MCP SDK only supports ASGI servers, this PR switches both our production and development servers from WSGI to ASGI.
 - For production, this was a simple change to our production image Dockerfile, which I'll verify on staging after we merge.
 - For development, the builtin Django devserver only supports WSGI, so I've had to intercept the `runserver` command to start up a `uvicorn` server instead.
 
 I've also added some basic MCP features:
  - The manifest schema as a regular MCP "resource" so models can access the schema manifest schema
  - All public schemas as "template" resources so models can access the manifest for each schema
  - A "tool" for listing all the current public schemas
  
 The MCP routes are hosted under "<host>/mcp/." (eg "http://localhost:8000/mcp/", note that the trailing slash is required at the moment). I've been using the [official MCP inspector](https://modelcontextprotocol.io/docs/tools/inspector) to test things out.
 
 Note that there's no authentication for the MCP server for now; I'll follow up with a separate issue for that, plus several more for additional tools/resources/fixes/etc. EDIT: #285 