### PR TITLE
Making PostgreSQL default in every environment

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -180,13 +180,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Create test environment file
-        run: |
-          echo "DEBUG=True" > .env
-          echo "DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres" >> .env
-          echo "SECRET_KEY=test-secret-key-for-ci" >> .env
-
       - name: Run Tests
+        env:
+          # Point suite at the postgres service defined above so tests run on PostgreSQL
+          DJ_DATABASE_CONN_STRING: postgres://postgres:postgres@localhost:5432/postgres
         run: pytest
 
   # Deploy to Google Cloud Run (staging environment)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ To run locally, you'll first need to install Python and pip.
 
 To install project dependencies with pip, run `pip install -r requirements.txt`.
 
+This project uses PostgreSQL in every environment, including local development.
+   
+The settings default to `postgres://postgres:postgres@localhost:5432/schemaindex`. If your local PostgreSQL uses different credentials, host, port, or database name, override the connection string by creating a git-ignored `.env` file in the project root:
+
+```sh
+# .env
+DJ_DATABASE_CONN_STRING=postgres://<user>:<password>@localhost:5432/<database>
+```
+
 To access the database management portal, create a superuser for yourself with `python3 manage.py createsuperuser`.
 
 To start the project, run `python3 manage.py runserver`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run locally, you'll first need to install Python and pip.
 To install project dependencies with pip, run `pip install -r requirements.txt`.
 
 This project uses PostgreSQL in every environment, including local development.
-   
+
 The settings default to `postgres://postgres:postgres@localhost:5432/schemaindex`. If your local PostgreSQL uses different credentials, host, port, or database name, override the connection string by creating a git-ignored `.env` file in the project root:
 
 ```sh

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -22,10 +22,11 @@ PROJECT_NAME = "SchemaIndex"
 SITE_URL = "[localhost]"
 SUPPORT_EMAIL = "support@dtinit.org"
 
-env = environ.Env()
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+env = environ.Env()
+env.read_env(os.path.join(BASE_DIR, ".env"))
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # This will be overridden in production/staging settings
@@ -80,10 +81,11 @@ TEMPLATES = [
 
 WSGI_APPLICATION = "schemaindex.wsgi.application"
 
-# Database (default SQLite for development)
+# Database (default PostgreSQL for every environment)
 DATABASES = {
     "default": env.db_url(
-        "DJ_DATABASE_CONN_STRING", default=f"sqlite:///{BASE_DIR / 'db.sqlite3'}"
+        "DJ_DATABASE_CONN_STRING",
+        default="postgres://postgres:postgres@localhost:5432/schemaindex",
     )
 }
 


### PR DESCRIPTION
This PR makes PostgreSQL the default in every env.

* `ci-cd.yaml` has a `test-python` job that starts a Postgres service and writes a `.env` with `DATABASE_URL` but `base.py` reads `DJ_DATABASE_CONN_STRING` and never calls `env.read_env()`. As a result the `.env` is ignored and the test suite appears to run on SQLite despite the Postgres service.


I thought of adding a `test_database_is_postgres()` guard but it will fail if any of us is not running Postgres for local development and continue using SQLite.

```python
from django.db import connection


def test_database_is_postgres():
    assert connection.vendor == "postgresql"
```