### PR TITLE
Handle get_schema '404' cases with a nicer error and add test

### DIFF
--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -55,15 +55,24 @@ async def get_schema(schema_id):
         if user and user.is_authenticated:
             schema_filter |= Q(created_by=user)
 
-        schema = (
-            Schema.objects
-            .prefetch_related("schemaref_set")
-            .prefetch_related("documentationitem_set")
-            .filter(schema_filter)
-            .get(pk=schema_id)
-        )
-        return schema.to_manifest()
+        try:
+            schema = (
+                Schema.objects
+                .prefetch_related("schemaref_set")
+                .prefetch_related("documentationitem_set")
+                .filter(schema_filter)
+                .get(pk=schema_id)
+            )
+            return schema.to_manifest()
+        except Schema.DoesNotExist:
+            return None
 
-    # Await the sync-to-async execution
     manifest = await fetch_from_db()
+
+    if manifest is None:
+        # The MCP SDK will wrap this nicely for the MCP client
+        raise ValueError(
+            f"Resource not found: Schema with ID '{schema_id}' does not exist or you lack permission to view it."
+        )
+
     return json.dumps(manifest, indent=2)

--- a/core/tests.py
+++ b/core/tests.py
@@ -1,1 +1,0 @@
-# Create your tests here.

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,7 +1,5 @@
 import pytest
-from collections.abc import AsyncGenerator
 import json
-from mcp.client.session import ClientSession
 from mcp.shared.memory import create_connected_server_and_client_session
 from asgiref.sync import sync_to_async
 from unittest.mock import patch, MagicMock
@@ -9,7 +7,7 @@ from starlette.responses import JSONResponse
 from django.test import override_settings
 from core.mcp.server import mcp
 from core.mcp.api_key_authentication import MCPAPIKeyAuthenticationMiddleware
-from factories import SchemaFactory, ProfileFactory
+from factories import SchemaFactory, ProfileFactory, UserFactory
 
 
 # Force all database tests in this file to flush tables instead of rolling back,
@@ -24,11 +22,22 @@ def anyio_backend():
 
 
 @pytest.fixture
-async def client_session() -> AsyncGenerator[ClientSession, None]:
+async def client_session():
     # Creates an isolated in-memory client session connected to your FastMCP server.
     # raise_exceptions=True ensures that internal server errors fail the test immediately.
     async with create_connected_server_and_client_session(
         mcp, raise_exceptions=True
+    ) as session:
+        yield session
+
+
+@pytest.fixture
+async def error_client_session():
+    # Creates a client session where the server catches unhandled exceptions
+    # and serializes them into MCP error payloads over the wire. Use this
+    # specifically for testing expected error states.
+    async with create_connected_server_and_client_session(
+        mcp, raise_exceptions=False
     ) as session:
         yield session
 
@@ -133,3 +142,21 @@ async def test_schema_by_id_resource_supports_own_private_schemas(client_session
     expected_manifest_str = json.dumps(manifest, sort_keys=True)
     # Now we have two JSON strings with sorted keys we can just compare directly
     assert sorted_contents_str == expected_manifest_str
+
+
+@pytest.mark.anyio
+async def test_schema_by_id_resource_errors_for_inaccessible_schemas(
+    error_client_session,
+):
+    # Create a private schema
+    schema = await sync_to_async(SchemaFactory.create)(published_at=None)
+
+    # Mock the current_user to be a completely different user from the creator
+    mock_current_user = MagicMock()
+    mock_current_user.get.return_value = await sync_to_async(UserFactory.create)()
+
+    with patch("core.mcp.server.current_user", mock_current_user):
+        expected_error_message = f"Resource not found: Schema with ID '{schema.id}' does not exist or you lack permission to view it."
+
+        with pytest.raises(Exception, match=expected_error_message):
+            await error_client_session.read_resource(f"schema://{schema.id}")


### PR DESCRIPTION
Merge after #305.

Closes #304.

Wraps get_resource with a more helpful error when the provided ID is either invalid or inaccessible to the user, plus a test to make sure users can't access other users' private schemas.