### PR TITLE
Add MCP tools to create and update schemas

### DIFF
--- a/core/api/views.py
+++ b/core/api/views.py
@@ -1,34 +1,22 @@
 import json
 from functools import wraps
-from django.utils import timezone
 from django.db import transaction
 from django.shortcuts import get_object_or_404, render
-from django.conf import settings
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.urls import reverse
-from jsonschema import validate, ValidationError as JSONValidationError
-from core.models import SchemaRef, Schema, ReferenceItem, PublishedSchemaConflictError
+from jsonschema import ValidationError as JSONValidationError
+from core.models import SchemaRef, Schema
 from core.api.responses import ApiResponse, ApiErrorResponse
 from core.views import lookup_schema
-
-
-def _load_manifest_schema():
-    schema_path = settings.BASE_DIR / "core" / "schemas" / "manifest.schema.json"
-    with open(schema_path, "r") as f:
-        return json.load(f)
-
-
-MANIFEST_SCHEMA = _load_manifest_schema()
 
 
 def require_manifest(function):
     @wraps(function)
     def _wrap_request(request, *args, **kwargs):
         try:
-            data = json.loads(request.body)
-            validate(instance=data, schema=MANIFEST_SCHEMA)
+            data = Schema.validate_manifest(request.body)
         except json.JSONDecodeError as e:
             return ApiErrorResponse(
                 status_code=400, message="Undecodable JSON payload", details=e.msg
@@ -42,66 +30,6 @@ def require_manifest(function):
         return function(request, manifest=data, *args, **kwargs)
 
     return _wrap_request
-
-
-@transaction.atomic
-def _save_manifest(manifest, schema, created_by):
-    schema.name = manifest["name"]
-    schema.description = manifest.get("description")
-    public = manifest.get("public") or False
-
-    # Warn users when attempting to make public schemas private
-    if not public and schema.published_at:
-        raise DjangoValidationError(
-            "Public schemas cannot be made private except by an admin. Please set `public: true` in your manifest."
-        )
-
-    schema.save()
-    urls = manifest["documents"].keys()
-
-    # Delete any ReferenceItems with URLs
-    # that aren't in the manifest
-    schema.schemaref_set.exclude(url__in=urls).delete()
-    schema.documentationitem_set.exclude(url__in=urls).delete()
-    schema.implementation_set.exclude(url__in=urls).delete()
-
-    # Create or update reference items
-    for document_url, document_metadata in manifest["documents"].items():
-        ReferenceItem.update_or_create_from_manifest_document(
-            schema, document_url, document_metadata, created_by
-        )
-
-    if public:
-        if schema.pk is None:
-            # Django requires a pk before we can use
-            # schema.check_for_published_conflicts()
-            schema.save()
-        else:
-            # Existing schemas were using stale schemaref_set
-            # data without this
-            schema.refresh_from_db()
-
-        try:
-            schema.check_for_published_conflicts()
-        except PublishedSchemaConflictError as e:
-            conflict_url = reverse(
-                "schema_ref_detail",
-                kwargs={
-                    "schema_id": e.conflicting_schema_ref.schema.id,
-                    "schema_ref_id": e.conflicting_schema_ref.id,
-                },
-            )
-            raise DjangoValidationError(
-                f"`public: true` was set, but a public schema ({conflict_url})"
-                + f"is already using one of the {e.reason} values "
-                + "used in this schema. Please contact a Schemas.Pub administrator."
-            )
-
-    # We only update published_at when we initially publish
-    if public and not schema.published_at:
-        schema.published_at = timezone.now()
-
-    schema.save()
 
 
 def docs(request):
@@ -125,7 +53,7 @@ def find(request):
 def schemas_create(request, manifest):
     schema = Schema(created_by=request.user)
     try:
-        _save_manifest(manifest, schema, created_by=request.user)
+        schema.overwrite_from_manifest(manifest)
     except DjangoValidationError as e:
         return ApiErrorResponse(
             status_code=400, message="Validation Error", details=e.message
@@ -152,7 +80,7 @@ def schemas_update(request, manifest, schema):
             details="You are not authorized to make changes to this schema",
         )
     try:
-        _save_manifest(manifest, schema, created_by=request.user)
+        schema.overwrite_from_manifest(manifest)
     except DjangoValidationError as e:
         return ApiErrorResponse(
             status_code=400, message="Validation Error", details=e.message

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -25,6 +25,19 @@ ID: {schema.id}
     return formatted_schema
 
 
+# This is just a fallback since our middleware
+# rejects any request without an API key tied to a user.
+def ensure_current_user():
+    user = current_user.get()
+    if not user:
+        raise ValueError("Not authenticated.")
+    return user
+
+
+# Note: We don't use type hints elsewhere in the codebase,
+# but they can influence FastMCP's behavior for tools and resources.
+
+
 # TODO: This will need to be paginated
 @mcp.tool()
 @sync_to_async
@@ -41,7 +54,7 @@ async def get_manifest_schema():
 
 
 @mcp.resource("schema://{schema_id}")
-async def get_schema(schema_id):
+async def get_schema(schema_id: int):
     """Get a schema's manifest"""
 
     user = current_user.get()
@@ -77,31 +90,59 @@ async def get_schema(schema_id):
     return json.dumps(manifest, indent=2)
 
 
+def _validate_manifest_and_update_schema(manifest, schema):
+    """
+    Shared synchronous helper to validate a manifest, apply it to a Schema instance,
+    and handle common validation exceptions.
+    """
+    try:
+        manifest_data = Schema.validate_manifest(manifest)
+        schema.overwrite_from_manifest(manifest_data)
+        return {
+            "id": schema.id,
+            "url": reverse("schema_detail", kwargs={"schema_id": schema.id}),
+        }
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Undecodable JSON payload: {e.msg}")
+    except JSONValidationError as e:
+        raise ValueError(f"Incorrect JSON payload format: {e.message}")
+    except DjangoValidationError as e:
+        raise ValueError(f"Validation Error: {e.message}")
+
+
 @mcp.tool()
 async def create_schema(manifest: str):
     """
     Create a new schema from a manifest.
-    The manifest should be a JSON string following the Schemas.Pub manifest schema available from schema://manifest.json
+    The manifest should be a JSON string following the Schemas.Pub manifest schema available at schema://manifest.json
     """
-    user = current_user.get()
-    if not user or not user.is_authenticated:
-        raise ValueError("You must be authenticated to create a schema.")
+    user = ensure_current_user()
 
     @sync_to_async
     def do_create():
-        try:
-            manifest_data = Schema.validate_manifest(manifest)
-            schema = Schema(created_by=user)
-            schema.overwrite_from_manifest(manifest_data)
-            return {
-                "id": schema.id,
-                "url": reverse("schema_detail", kwargs={"schema_id": schema.id}),
-            }
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Undecodable JSON payload: {e.msg}")
-        except JSONValidationError as e:
-            raise ValueError(f"Incorrect JSON payload format: {e.message}")
-        except DjangoValidationError as e:
-            raise ValueError(f"Validation Error: {e.message}")
+        schema = Schema(created_by=user)
+        return _validate_manifest_and_update_schema(manifest, schema)
 
     return await do_create()
+
+
+@mcp.tool()
+async def update_schema(schema_id: int, manifest: str):
+    """
+    Update an existing schema from a manifest.
+    The manifest should be a JSON string following the Schemas.Pub manifest schema available at schema://manifest.json
+    """
+    user = ensure_current_user()
+
+    @sync_to_async
+    def do_update():
+        try:
+            schema = Schema.objects.get(pk=schema_id)
+            if schema.created_by != user:
+                raise Schema.DoesNotExist
+        except Schema.DoesNotExist:
+            raise ValueError(f"Schema with ID '{schema_id}' not found.")
+
+        return _validate_manifest_and_update_schema(manifest, schema)
+
+    return await do_update()

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -1,7 +1,9 @@
 import json
+from jsonschema import ValidationError as JSONValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.urls import reverse
 from django.db.models import Q
 from django.utils import timezone
-from django.conf import settings
 from mcp.server.fastmcp import FastMCP
 from core.models import Schema
 from asgiref.sync import sync_to_async
@@ -35,10 +37,7 @@ def list_schemas():
 @mcp.resource("schema://manifest.json")
 async def get_manifest_schema():
     """Get the Schemas.Pub manifest schema"""
-    # TODO: dedupe from api_views.py
-    schema_path = settings.BASE_DIR / "core" / "schemas" / "manifest.schema.json"
-    with open(schema_path, "r") as f:
-        return f.read()
+    return json.dumps(Schema.get_manifest_schema())
 
 
 @mcp.resource("schema://{schema_id}")
@@ -76,3 +75,33 @@ async def get_schema(schema_id):
         )
 
     return json.dumps(manifest, indent=2)
+
+
+@mcp.tool()
+async def create_schema(manifest: str):
+    """
+    Create a new schema from a manifest.
+    The manifest should be a JSON string following the Schemas.Pub manifest schema available from schema://manifest.json
+    """
+    user = current_user.get()
+    if not user or not user.is_authenticated:
+        raise ValueError("You must be authenticated to create a schema.")
+
+    @sync_to_async
+    def do_create():
+        try:
+            manifest_data = Schema.validate_manifest(manifest)
+            schema = Schema(created_by=user)
+            schema.overwrite_from_manifest(manifest_data)
+            return {
+                "id": schema.id,
+                "url": reverse("schema_detail", kwargs={"schema_id": schema.id}),
+            }
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Undecodable JSON payload: {e.msg}")
+        except JSONValidationError as e:
+            raise ValueError(f"Incorrect JSON payload format: {e.message}")
+        except DjangoValidationError as e:
+            raise ValueError(f"Validation Error: {e.message}")
+
+    return await do_create()

--- a/core/models.py
+++ b/core/models.py
@@ -9,12 +9,14 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.hashers import make_password, check_password
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
+from django.urls import reverse
 from urllib.parse import urlparse
 import time
 import requests
 import requests.exceptions
 import secrets
 import json
+from jsonschema import validate as validate_json_schema
 from django.core.mail import send_mail
 from .utils import (
     guess_specification_language_by_extension,
@@ -135,6 +137,18 @@ class Schema(BaseModel):
 
         super().save(*args, **kwargs)
 
+    @classmethod
+    def get_manifest_schema(cls):
+        schema_path = settings.BASE_DIR / "core" / "schemas" / "manifest.schema.json"
+        with open(schema_path, "r") as f:
+            return json.load(f)
+
+    @classmethod
+    def validate_manifest(cls, manifest_string):
+        data = json.loads(manifest_string)
+        validate_json_schema(instance=data, schema=cls.get_manifest_schema())
+        return data
+
     @property
     def is_published(self):
         return self.published_at is not None and self.published_at <= timezone.now()
@@ -250,6 +264,65 @@ class Schema(BaseModel):
         manifest["documents"] = documents
 
         return manifest
+
+    @transaction.atomic
+    def overwrite_from_manifest(self, manifest):
+        self.name = manifest["name"]
+        self.description = manifest.get("description")
+        public = manifest.get("public") or False
+
+        # Warn users when attempting to make public schemas private
+        if not public and self.published_at:
+            raise ValidationError(
+                "Public schemas cannot be made private except by an admin. Please set `public: true` in your manifest."
+            )
+
+        self.save()
+        urls = manifest["documents"].keys()
+
+        # Delete any ReferenceItems with URLs
+        # that aren't in the manifest
+        self.schemaref_set.exclude(url__in=urls).delete()
+        self.documentationitem_set.exclude(url__in=urls).delete()
+        self.implementation_set.exclude(url__in=urls).delete()
+
+        # Create or update reference items
+        for document_url, document_metadata in manifest["documents"].items():
+            ReferenceItem.update_or_create_from_manifest_document(
+                self, document_url, document_metadata, created_by=self.created_by
+            )
+
+        if public:
+            if self.pk is None:
+                # Django requires a pk before we can use
+                # schema.check_for_published_conflicts()
+                self.save()
+            else:
+                # Existing schemas were using stale schemaref_set
+                # data without this
+                self.refresh_from_db()
+
+            try:
+                self.check_for_published_conflicts()
+            except PublishedSchemaConflictError as e:
+                conflict_url = reverse(
+                    "schema_ref_detail",
+                    kwargs={
+                        "schema_id": e.conflicting_schema_ref.schema.id,
+                        "schema_ref_id": e.conflicting_schema_ref.id,
+                    },
+                )
+                raise ValidationError(
+                    f"`public: true` was set, but a public schema ({conflict_url})"
+                    + f"is already using one of the {e.reason} values "
+                    + "used in this schema. Please contact a Schemas.Pub administrator."
+                )
+
+        # We only update published_at when we initially publish
+        if public and not self.published_at:
+            self.published_at = timezone.now()
+
+        self.save()
 
 
 class ReferenceItemManager(models.Manager):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,33 @@
 import pytest
 from django.core.cache import cache
 from django.test import Client
+from django.db import connection
 import requests_mock as requests_mock_lib
 from factories import ProfileFactory
+
+
+@pytest.fixture(scope="session", autouse=True)
+def force_terminate_db_connections(django_db_setup, django_db_blocker):
+    """
+    Hooks into pytest-django's teardown lifecycle.
+    Guarantees that all background thread connections are killed
+    before pytest tries to drop the test database.
+    """
+    yield
+
+    with django_db_blocker.unblock():
+        with connection.cursor() as cursor:
+            db_name = connection.settings_dict["NAME"]
+            cursor.execute(
+                f"""
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = '{db_name}'
+                  AND pid <> pg_backend_pid();
+                """
+            )
+
+        connection.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -177,12 +177,12 @@ async def test_create_schema_success(client_session, current_user_mock):
     current_user_mock.get.return_value = user
 
     manifest = {
-        "name": "MCP Test Schema",
+        "name": "Test Schema",
         "description": "A schema created via MCP tool",
         "documents": {
             "https://example.com/mcp-definition.json": {
                 "type": "definition",
-                "name": "MCP Definition",
+                "name": "Test Definition",
             },
         },
     }
@@ -205,7 +205,7 @@ async def test_create_schema_unauthenticated(error_client_session, current_user_
     # Mock the current_user to be None or unauthenticated
     current_user_mock.get.return_value = None
 
-    expected_error_message = "You must be authenticated to create a schema."
+    expected_error_message = "Not authenticated."
     result = await error_client_session.call_tool(
         "create_schema", arguments={"manifest": "{}"}
     )
@@ -264,6 +264,140 @@ async def test_create_schema_validation_error(error_client_session, current_user
     expected_error_message = "Validation Error"
     result = await error_client_session.call_tool(
         "create_schema", arguments={"manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_success(client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    schema = await sync_to_async(SchemaFactory.create)(created_by=user)
+
+    manifest = {
+        "name": "Test Schema",
+        "description": "A schema updated via MCP tool",
+        "documents": {
+            "https://example.com/mcp-definition.json": {
+                "type": "definition",
+                "name": "Test Definition",
+            },
+        },
+        "public": True,
+    }
+    manifest_str = json.dumps(manifest)
+
+    result = await client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": manifest_str}
+    )
+
+    parsed_result = json.loads(result.content[0].text)
+    assert "id" in parsed_result
+    assert "url" in parsed_result
+    assert parsed_result["id"] == schema.id
+
+    updated_schema = await sync_to_async(Schema.objects.get)(id=parsed_result["id"])
+    await sync_to_async(assert_schema_matches_manifest)(updated_schema, manifest)
+
+
+@pytest.mark.anyio
+async def test_update_schema_unauthenticated(error_client_session, current_user_mock):
+    # Mock the current_user to be None or unauthenticated
+    current_user_mock.get.return_value = None
+    schema = await sync_to_async(SchemaFactory.create)()
+
+    expected_error_message = "Not authenticated."
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": "{}"}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_forbidden(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    # Schema created by another user
+    other_user = await sync_to_async(UserFactory.create)()
+    schema = await sync_to_async(SchemaFactory.create)(created_by=other_user)
+
+    expected_error_message = f"Schema with ID '{schema.id}' not found."
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": "{}"}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_not_found(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    # Schema does not exist
+    non_existent_id = 99999
+    expected_error_message = f"Schema with ID '{non_existent_id}' not found."
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": non_existent_id, "manifest": "{}"}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_invalid_json(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    schema = await sync_to_async(SchemaFactory.create)(created_by=user)
+    # Intentionally invalid JSON
+    manifest_str = '{"name": "Invalid JSON", '
+    expected_error_message = "Undecodable JSON payload"
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_invalid_manifest_format(
+    error_client_session, current_user_mock
+):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    schema = await sync_to_async(SchemaFactory.create)(created_by=user)
+    # Valid JSON, but not a valid manifest
+    manifest_str = json.dumps({"wrong_key": "wrong_value"})
+    expected_error_message = "Incorrect JSON payload format"
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_update_schema_validation_error(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    schema = await sync_to_async(SchemaFactory.create)(created_by=user)
+
+    other_user = await sync_to_async(UserFactory.create)()
+    published_schema = await sync_to_async(SchemaFactory.create)(created_by=other_user)
+    url = "https://example.com/conflict.json"
+    await sync_to_async(SchemaRefFactory.create)(schema=published_schema, url=url)
+
+    manifest = {
+        "name": "Conflict Schema",
+        "public": True,
+        "documents": {url: {"type": "definition"}},
+    }
+    manifest_str = json.dumps(manifest)
+
+    expected_error_message = "Validation Error"
+    result = await error_client_session.call_tool(
+        "update_schema", arguments={"schema_id": schema.id, "manifest": manifest_str}
     )
     assert result.isError
     assert expected_error_message in result.content[0].text

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -7,7 +7,9 @@ from starlette.responses import JSONResponse
 from django.test import override_settings
 from core.mcp.server import mcp
 from core.mcp.api_key_authentication import MCPAPIKeyAuthenticationMiddleware
-from factories import SchemaFactory, ProfileFactory, UserFactory
+from factories import SchemaFactory, ProfileFactory, UserFactory, SchemaRefFactory
+from utils import assert_schema_matches_manifest
+from core.models import Schema
 
 
 # Force all database tests in this file to flush tables instead of rolling back,
@@ -29,6 +31,14 @@ async def client_session():
         mcp, raise_exceptions=True
     ) as session:
         yield session
+
+
+@pytest.fixture
+def current_user_mock():
+    # Patches current_user for the duration of the test.
+    mock = MagicMock()
+    with patch("core.mcp.server.current_user", mock):
+        yield mock
 
 
 @pytest.fixture
@@ -128,14 +138,14 @@ async def test_schema_by_id_resource(client_session):
 
 
 @pytest.mark.anyio
-async def test_schema_by_id_resource_supports_own_private_schemas(client_session):
+async def test_schema_by_id_resource_supports_own_private_schemas(
+    client_session, current_user_mock
+):
     schema = await sync_to_async(SchemaFactory.create)(published_at=None)
     manifest = await sync_to_async(schema.to_manifest)()
     # Mock the current_user (normally provided by middleware)
-    mock_current_user = MagicMock()
-    mock_current_user.get.return_value = schema.created_by
-    with patch("core.mcp.server.current_user", mock_current_user):
-        result = await client_session.read_resource(f"schema://{schema.id}")
+    current_user_mock.get.return_value = schema.created_by
+    result = await client_session.read_resource(f"schema://{schema.id}")
     # We parse the string result as JSON so we can stringify it with sorted keys
     parsed_contents = json.loads(result.contents[0].text)
     sorted_contents_str = json.dumps(parsed_contents, sort_keys=True)
@@ -147,16 +157,113 @@ async def test_schema_by_id_resource_supports_own_private_schemas(client_session
 @pytest.mark.anyio
 async def test_schema_by_id_resource_errors_for_inaccessible_schemas(
     error_client_session,
+    current_user_mock,
 ):
     # Create a private schema
     schema = await sync_to_async(SchemaFactory.create)(published_at=None)
 
     # Mock the current_user to be a completely different user from the creator
-    mock_current_user = MagicMock()
-    mock_current_user.get.return_value = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = await sync_to_async(UserFactory.create)()
 
-    with patch("core.mcp.server.current_user", mock_current_user):
-        expected_error_message = f"Resource not found: Schema with ID '{schema.id}' does not exist or you lack permission to view it."
+    expected_error_message = f"Resource not found: Schema with ID '{schema.id}' does not exist or you lack permission to view it."
 
-        with pytest.raises(Exception, match=expected_error_message):
-            await error_client_session.read_resource(f"schema://{schema.id}")
+    with pytest.raises(Exception, match=expected_error_message):
+        await error_client_session.read_resource(f"schema://{schema.id}")
+
+
+@pytest.mark.anyio
+async def test_create_schema_success(client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+
+    manifest = {
+        "name": "MCP Test Schema",
+        "description": "A schema created via MCP tool",
+        "documents": {
+            "https://example.com/mcp-definition.json": {
+                "type": "definition",
+                "name": "MCP Definition",
+            },
+        },
+    }
+    manifest_str = json.dumps(manifest)
+
+    result = await client_session.call_tool(
+        "create_schema", arguments={"manifest": manifest_str}
+    )
+
+    parsed_result = json.loads(result.content[0].text)
+    assert "id" in parsed_result
+    assert "url" in parsed_result
+
+    schema = await sync_to_async(Schema.objects.get)(id=parsed_result["id"])
+    await sync_to_async(assert_schema_matches_manifest)(schema, manifest)
+
+
+@pytest.mark.anyio
+async def test_create_schema_unauthenticated(error_client_session, current_user_mock):
+    # Mock the current_user to be None or unauthenticated
+    current_user_mock.get.return_value = None
+
+    expected_error_message = "You must be authenticated to create a schema."
+    result = await error_client_session.call_tool(
+        "create_schema", arguments={"manifest": "{}"}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_create_schema_invalid_json(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+
+    # Intentionally invalid JSON
+    manifest_str = '{"name": "Invalid JSON", '
+    expected_error_message = "Undecodable JSON payload"
+    result = await error_client_session.call_tool(
+        "create_schema", arguments={"manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_create_schema_invalid_manifest_format(
+    error_client_session, current_user_mock
+):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+
+    # Valid JSON, but not a valid manifest
+    manifest_str = json.dumps({"wrong_key": "wrong_value"})
+    expected_error_message = "Incorrect JSON payload format"
+    result = await error_client_session.call_tool(
+        "create_schema", arguments={"manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text
+
+
+@pytest.mark.anyio
+async def test_create_schema_validation_error(error_client_session, current_user_mock):
+    user = await sync_to_async(UserFactory.create)()
+    current_user_mock.get.return_value = user
+    other_user = await sync_to_async(UserFactory.create)()
+    published_schema = await sync_to_async(SchemaFactory.create)(created_by=other_user)
+    url = "https://example.com/conflict.json"
+    await sync_to_async(SchemaRefFactory.create)(schema=published_schema, url=url)
+
+    manifest = {
+        "name": "Conflict Schema",
+        "public": True,
+        "documents": {url: {"type": "definition"}},
+    }
+    manifest_str = json.dumps(manifest)
+
+    expected_error_message = "Validation Error"
+    result = await error_client_session.call_tool(
+        "create_schema", arguments={"manifest": manifest_str}
+    )
+    assert result.isError
+    assert expected_error_message in result.content[0].text


### PR DESCRIPTION
Closes #290. Closes #291.

Adds `create_schema` and `update_schema` as MCP tools.

This involved moving what was previously an api-only helper method for updating a Schema from a manifest (`_save_manifest`) onto the `Schema` model as `overwrite_from_model` so it could be shared by the API views and the MCP tools. Additionally, `get_manifest` and `validate_manifest` were added as class methods onto `Schema` so they can also be shared.