### PR TITLE
Implement configurable domain allowlist for content hosts

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -4,7 +4,10 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 import requests
 from .models import DocumentationItem, SchemaRef, Schema, PermanentURL
-from .utils import guess_specification_language_by_extension
+from .utils import (
+    guess_specification_language_by_extension,
+    is_trusted_content_host_url,
+)
 
 
 # These are just alphabetized and shown as help text
@@ -34,6 +37,9 @@ class ReferenceItemForm(forms.Form):
 
 
 def clean_url_and_get_body(url):
+    if not is_trusted_content_host_url(url):
+        return ""
+
     try:
         response = requests.get(url)
     except requests.exceptions.RequestException:

--- a/core/models.py
+++ b/core/models.py
@@ -21,6 +21,7 @@ from django.core.mail import send_mail
 from .utils import (
     guess_specification_language_by_extension,
     guess_language_by_extension,
+    is_trusted_content_host_url,
 )
 
 logger = logging.getLogger("schemaindex")
@@ -527,6 +528,7 @@ class ReferenceItem(BaseModel):
             if original.url != self.url:
                 self.content_fetch_failing_since = None
                 self.delete_cached_content()
+
         super().save(*args, **kwargs)
 
     def _get_content_url(self):
@@ -586,6 +588,9 @@ class ReferenceItem(BaseModel):
                     raise last_exception  # Re-raise the last exception after all retries and email logic
 
     def get_content(self):
+        if not is_trusted_content_host_url(self._get_content_url()):
+            return ""
+
         # Fetch remote file content, using cache when available
         cache_key = self._cache_key()
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,6 +1,7 @@
 from urllib.parse import urlparse
 from pygments.lexers import get_lexer_for_filename
 from pygments.util import ClassNotFound
+from django.conf import settings
 
 """
 This is currently just a list of languages supported
@@ -77,3 +78,18 @@ def guess_specification_language_by_extension(url):
     of allowed specification languages, or None if no such match exists.
     """
     return guess_language_by_extension(url, SPECIFICATION_LANGUAGE_ALLOWLIST)
+
+
+def is_trusted_content_host_url(url):
+    parsed_url = urlparse(url)
+    hostname = parsed_url.hostname
+
+    if not hostname:
+        return False
+
+    if hostname in settings.TRUSTED_CONTENT_DOMAINS:
+        return True
+
+    return any(
+        hostname.endswith("." + domain) for domain in settings.TRUSTED_CONTENT_DOMAINS
+    )

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -192,3 +192,14 @@ HOURLY_API_REQUEST_LIMIT = 500
 
 # Feature flags
 ENABLE_MCP_SERVER = False
+
+# An allowlist of domains we can safely fetch file content from
+TRUSTED_CONTENT_DOMAINS = [
+    "github.com",
+    "githubusercontent.com",
+    "w3.org",
+    "happenstance.ai",
+    "osirisjson.org",
+    "ietf.org",
+    "rfc-editor.org",
+]

--- a/schemaindex/settings/testing.py
+++ b/schemaindex/settings/testing.py
@@ -3,3 +3,4 @@ from .base import *
 PERMANENT_URL_HOST = "testserver"
 ALLOWED_HOSTS = [PERMANENT_URL_HOST]
 SITE_URL = f"http://{PERMANENT_URL_HOST}"
+TRUSTED_CONTENT_DOMAINS.append("example.com")

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -88,7 +88,6 @@ def test_schema_management_form_prevents_duplicate_published_id_values():
             },
         )
         assert not form.is_valid()
-        print(form.schema_refs_formset.errors[0])
         error = form.schema_refs_formset.errors[0]["url"][
             0
         ]  # Form 0, error list for 'url', error 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from django.core import mail
 from django.contrib.auth.hashers import make_password
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 from core.models import Schema, SchemaRef, APIKey
 from factories import (
     UserFactory,
@@ -99,7 +100,7 @@ def test_reference_item_content_is_fetched_from_raw_url_if_available():
 @pytest.mark.django_db
 @patch("core.models.time.sleep", return_value=None)
 def test_reference_item_get_content_success(mock_sleep):
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition.md")
     mock_content = "some content"
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, text=mock_content)
@@ -112,7 +113,7 @@ def test_reference_item_get_content_success(mock_sleep):
 @pytest.mark.django_db
 @patch("core.models.time.sleep", return_value=None)
 def test_reference_item_get_content_failure_sends_email_and_sets_timestamp(mock_sleep):
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, status_code=500)
         with pytest.raises(requests.exceptions.HTTPError):
@@ -130,7 +131,10 @@ def test_reference_item_get_content_subsequent_failure_no_email_or_timestamp_cha
     mock_sleep,
 ):
     mock_failure_time = timezone.now() - timezone.timedelta(hours=1)
-    schema_ref = SchemaRefFactory.create(content_fetch_failing_since=mock_failure_time)
+    schema_ref = SchemaRefFactory.create(
+        content_fetch_failing_since=mock_failure_time,
+        url="https://example.com/definition",
+    )
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, status_code=500)
         with pytest.raises(requests.exceptions.HTTPError):
@@ -145,7 +149,8 @@ def test_reference_item_get_content_subsequent_failure_no_email_or_timestamp_cha
 @patch("core.models.time.sleep", return_value=None)
 def test_reference_item_get_content_success_after_failure_clears_timestamp(mock_sleep):
     schema_ref = SchemaRefFactory.create(
-        content_fetch_failing_since=timezone.now() - timezone.timedelta(hours=1)
+        content_fetch_failing_since=timezone.now() - timezone.timedelta(hours=1),
+        url="https://example.com/definition",
     )
     mock_content = "some content"
     with requests_mock.Mocker() as m:
@@ -159,7 +164,7 @@ def test_reference_item_get_content_success_after_failure_clears_timestamp(mock_
 @pytest.mark.django_db
 @patch("core.models.time.sleep", return_value=None)
 def test_reference_item_get_content_retries_on_unreachable(mock_sleep):
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, exc=requests.exceptions.HTTPError)
         with pytest.raises(requests.exceptions.HTTPError):
@@ -173,7 +178,7 @@ def test_reference_item_get_content_retries_on_unreachable(mock_sleep):
 @pytest.mark.django_db
 def test_reference_item_save_resets_failure_timestamp_on_url_change():
     schema_ref = SchemaRefFactory.create(
-        content_fetch_failing_since=timezone.now(),
+        content_fetch_failing_since=timezone.now(), url="https://example.com/definition"
     )
     schema_ref.url = "https://example.com/new-url"
     schema_ref.save()
@@ -186,6 +191,7 @@ def test_reference_item_save_does_not_reset_failure_timestamp_on_other_change():
     schema_ref = SchemaRefFactory.create(
         content_fetch_failing_since=now,
         name="Old Name",
+        url="https://example.com/definition",
     )
     schema_ref.name = "New Name"
     schema_ref.save()
@@ -195,7 +201,7 @@ def test_reference_item_save_does_not_reset_failure_timestamp_on_other_change():
 @pytest.mark.django_db
 @patch("core.models.time.sleep", return_value=None)
 def test_reference_item_get_content_no_email_on_non_http_error(mock_sleep):
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, exc=requests.exceptions.ConnectionError)
         with pytest.raises(requests.exceptions.ConnectionError):
@@ -212,7 +218,7 @@ def test_reference_item_get_content_returns_cached_on_second_call():
     After a successful fetch, subsequent calls should return
     cached content without making another HTTP request.
     """
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
     mock_content = "cached schema content"
     with requests_mock.Mocker() as m:
         m.get(schema_ref.url, text=mock_content)
@@ -248,8 +254,8 @@ def test_reference_item_url_change_invalidates_cached_content():
 
 @pytest.mark.django_db
 def test_reference_item_cache_key_is_class_scoped():
-    schema_ref = SchemaRefFactory.create()
-    doc_item = DocumentationItemFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
+    doc_item = DocumentationItemFactory.create(url="https://example.com/readme.md")
 
     # Force the same pk to make the collision risk explicit. Even if
     # both rows share pk=N, the cache keys must differ.
@@ -267,7 +273,7 @@ def test_reference_item_get_content_falls_through_when_cache_get_returns_none():
     unreachable with IGNORE_EXCEPTIONS=True returning None). Each call
     must re-fetch from the remote URL and must not crash.
     """
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
 
     with requests_mock.Mocker() as m, patch.object(cache, "get", return_value=None):
         m.get(schema_ref.url, text="fresh remote content")
@@ -284,7 +290,7 @@ def test_reference_item_get_content_logs_backend_fallback_when_cache_set_raises(
     """If cache.set raises (IGNORE_EXCEPTIONS should swallow, but we still want a signal),
     get_content must still return the remote content and emit the backend-fallback log.
     """
-    schema_ref = SchemaRefFactory.create()
+    schema_ref = SchemaRefFactory.create(url="https://example.com/definition")
 
     with (
         requests_mock.Mocker() as m,
@@ -441,3 +447,38 @@ def test_schema_published_at_can_be_changed_by_admins():
     schema.save(is_admin_change=True)
     schema.refresh_from_db()
     assert schema.published_at == published_at_value
+
+
+@pytest.mark.django_db
+@override_settings(TRUSTED_CONTENT_DOMAINS=["example.com"])
+def test_schema_ref_get_content_fetches_from_trusted_domain():
+    mock_url = "https://example.com/definition"
+    expected_content = "hello from a safe domain"
+    with requests_mock.Mocker() as m:
+        m.get(mock_url, text=expected_content)
+        schema_ref = SchemaRefFactory.create(url=mock_url)
+        content = schema_ref.get_content()
+        assert expected_content == content
+
+
+@pytest.mark.django_db
+@override_settings(TRUSTED_CONTENT_DOMAINS=["example.com"])
+def test_schema_ref_get_content_fetches_from_trusted_subdomain():
+    mock_url = "https://schemas.example.com/definition"
+    expected_content = "hello from a safe domain"
+    with requests_mock.Mocker() as m:
+        m.get(mock_url, text=expected_content)
+        schema_ref = SchemaRefFactory.create(url=mock_url)
+        content = schema_ref.get_content()
+        assert expected_content == content
+
+
+@pytest.mark.django_db
+@override_settings(TRUSTED_CONTENT_DOMAINS=[])
+def test_schema_ref_get_content_ignores_untrusted_domain():
+    mock_url = "https://example.com/definition"
+    with requests_mock.Mocker() as m:
+        m.get(mock_url, text="If you can read this, the test failed")
+        schema_ref = SchemaRefFactory.create(url=mock_url)
+        content = schema_ref.get_content()
+        assert content == ""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -410,6 +410,7 @@ def test_schema_detail_renders_readme_on_successful_fetch():
         schema=schema,
         role=DocumentationItem.DocumentationItemRole.README,
         format=DocumentationItem.DocumentationItemFormat.PlainText,
+        url="https://example.com/readme",
     )
     client = Client()
     with requests_mock.Mocker() as m:


### PR DESCRIPTION
Temporarily adds an allowlist of domains from which we can safely make content requests to.

Fast-tracking deployment and will follow up with an issue.

EDIT: See #312