### PR TITLE
MCP Documentation

### DIFF
--- a/core/api/views.py
+++ b/core/api/views.py
@@ -1,7 +1,7 @@
 import json
 from functools import wraps
 from django.db import transaction
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ValidationError as DjangoValidationError
@@ -30,10 +30,6 @@ def require_manifest(function):
         return function(request, manifest=data, *args, **kwargs)
 
     return _wrap_request
-
-
-def docs(request):
-    return render(request, "core/api/docs.html")
 
 
 @require_GET

--- a/core/context_processors.py
+++ b/core/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def export_feature_flags(request):
+    return {
+        "feature_flags": {
+            "mcp_server": settings.ENABLE_MCP_SERVER,
+        }
+    }

--- a/core/middleware/api_key_authentication.py
+++ b/core/middleware/api_key_authentication.py
@@ -14,7 +14,7 @@ class APIKeyAuthenticationMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if not request.path.startswith("/api/") or request.path == "/api/docs":
+        if not request.path.startswith("/api/"):
             return self.get_response(request)
 
         api_key_header = request.headers.get(API_KEY_HEADER)

--- a/core/templates/account/api_key.html
+++ b/core/templates/account/api_key.html
@@ -13,7 +13,7 @@ API Key
     <input readonly value="{{ new_api_key }}" />
     This API key will not be shown again, but you can replace it with a new key later. Please treat it as you would a password.
     {% else %}
-    <p>Create an API key to use with the <a href="{% url 'api_docs' %}">Schemas.Pub API</a>.</p>
+    <p>Create an API key to use with the <a href="{% url 'docs_api' %}">Schemas.Pub API</a>{% if feature_flags.mcp_server %} and <a href="{% url 'docs_mcp' %}">MCP server</a>{% endif %}.</p>
     {% if request.user.profile.api_key %}
     <p>Warning: Creating a new API key will invalidate your previous key created on {{ request.user.profile.api_key.created_at|date }}.</p>
     {% endif %}

--- a/core/templates/core/docs/api.html
+++ b/core/templates/core/docs/api.html
@@ -12,7 +12,7 @@ Schemas.Pub - API Documentation
   {% if request.user %}
   You can create an API key <a href="{% url 'account_api_key' %}">here</a>.
   {% else %}
-  <a href="{ url 'account_signup'}">Create an account</a> to get an API key.
+  <a href="{% url 'account_signup' %}">Create an account</a> to get an API key.
   {% endif %}
   </p>
   <h2>Methods</h2>
@@ -57,7 +57,7 @@ Schemas.Pub - API Documentation
     <p>Creates a new schema.</p>
     <h4>Body</h4>
     <p>
-      The body of your request should be a <a href="https://schemas.pub/schemas/30">Schemas.Pub manifest</a>.
+      The body of your request should be a <a href="https://id.schemas.pub/o/DTI/manifest.schema.json">Schemas.Pub manifest</a>.
     </p>
     <h4>Response</h4>
     <p>A JSON object containing a "data" object with the following proprties:</p>
@@ -80,7 +80,7 @@ Schemas.Pub - API Documentation
     <p>Updates the specified schema.</p>
     <h4>Body</h4>
     <p>
-      The body of your request should be a <a href="https://schemas.pub/schemas/30">Schemas.Pub manifest</a>.
+      The body of your request should be a <a href="https://id.schemas.pub/o/DTI/manifest.schema.json">Schemas.Pub manifest</a>.
     </p>
     <h4>Response</h4>
     <p>A JSON object containing a "data" object with the following proprties:</p>

--- a/core/templates/core/docs/mcp.html
+++ b/core/templates/core/docs/mcp.html
@@ -1,0 +1,62 @@
+{% extends "core/layouts/base.html" %}
+{% block head_title %}
+Schemas.Pub - MCP Documentation
+{% endblock %}
+
+{% block page_content %}
+<main class="api-docs">
+  <h1>MCP Server Documentation</h1>
+  <p>
+    Schemas.Pub provides a Model Context Protocol (MCP) server that allows MCP-compatible clients to search for, create, and update schemas directly.
+  </p>
+
+  <h2>Authentication</h2>
+  <p>
+    All requests to the MCP server require an X-API-Key header with a valid API key.
+  {% if request.user %}
+  You can create or manage your API key <a href="{% url 'account_api_key' %}">here</a>.
+  {% else %}
+  <a href="{% url 'account_signup' %}">Create an account</a> to get an API key.
+  {% endif %}
+  </p>
+
+  <h2>Capabilities</h2>
+  <p>
+    The MCP server adds the following functionality to your MCP client:
+  </p>
+  <section class="method">
+    <h3><code>search_schemas</code></h3>
+    <p>
+      The <code>search_schemas</code> tool that allows the client to browse and search for schemas by keywords or by a JSON schema's <code>$id</code>.
+    </p>
+  </section>
+  <section class="method">
+    <h3>Access schemas</h3>
+    <p>
+      Individual schema manifests can be retrieved as MCP resources using the following URI template:
+    </p>
+    <code>
+      <pre>schema://[schema_id]</pre>
+    </code>
+    <p>where <code>[schema_id]</code> is the numeric ID of the schema.</p>
+  </section>
+  <section class="method">
+    <h3><code>create_schema</code></h3>
+    <p>
+      The <code>create_schema</code> tool enables the client to create new schemas from a <a href="https://id.schemas.pub/o/DTI/manifest.schema.json">Schemas.Pub manifest</a>.
+    </p>
+  </section>
+  <section class="method">
+    <h3><code>update_schema</code></h3>
+    <p>
+      The <code>update_schema</code> tool enables the client to update your schemas from a <a href="https://id.schemas.pub/o/DTI/manifest.schema.json">Schemas.Pub manifest</a>.
+    </p>
+  </section>
+  <section class="method">
+    <h3>Access manifest schema definition</h3>
+    <p>
+      The <a href="https://id.schemas.pub/o/DTI/manifest.schema.json">Schemas.Pub manifest</a> itself can be retrieved as an MCP resource at <code>schema://manifest.json</code>
+    </p>
+  </section>
+ </main>
+{% endblock %}

--- a/core/templates/core/partials/footer.html
+++ b/core/templates/core/partials/footer.html
@@ -5,7 +5,10 @@
     >Contact</a>
     <a href="{% url 'terms_of_use' %}">Terms of Use</a>
     <a href="{% url 'privacy_policy' %}">Privacy Policy</a>
-    <a href="{% url 'api_docs' %}">API</a>
+    <a href="{% url 'docs_api' %}">API</a>
+    {% if feature_flags.mcp_server %}
+    <a href="{% url 'docs_mcp' %}">MCP</a>
+    {% endif %}
   </nav>
   <div>&copy; {% now "Y" %} <a href="https://dtinit.org">Data Transfer
     Initiative.</a></div>

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,5 +1,4 @@
 from django.urls import path, include
-from django.conf import settings
 
 from . import views
 from core.api import views as api_views
@@ -16,6 +15,7 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("about", views.about),
     path("docs/api", views.docs_api, name="docs_api"),
+    path("docs/mcp", views.docs_mcp, name="docs_mcp"),
     path("terms-of-use", views.terms_of_use, name="terms_of_use"),
     path("privacy", views.privacy_policy, name="privacy_policy"),
     path("schemas/<int:schema_id>", views.schema_detail, name="schema_detail"),
@@ -66,6 +66,3 @@ urlpatterns = [
     ),
     path("api/", include(api_endpoints)),
 ]
-
-if settings.ENABLE_MCP_SERVER:
-    urlpatterns.append(path("docs/mcp", views.docs_mcp, name="docs_mcp"))

--- a/core/urls.py
+++ b/core/urls.py
@@ -5,7 +5,6 @@ from . import views
 from core.api import views as api_views
 
 api_endpoints = [
-    path("docs", api_views.docs, name="api_docs"),
     path("find", api_views.find, name="api_find"),
     path("schemas", api_views.schemas_create, name="api_schemas_create"),
     path(
@@ -16,6 +15,7 @@ api_endpoints = [
 urlpatterns = [
     path("", views.index, name="index"),
     path("about", views.about),
+    path("docs/api", views.docs_api, name="docs_api"),
     path("terms-of-use", views.terms_of_use, name="terms_of_use"),
     path("privacy", views.privacy_policy, name="privacy_policy"),
     path("schemas/<int:schema_id>", views.schema_detail, name="schema_detail"),

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path, include
+from django.conf import settings
 
 from . import views
 from core.api import views as api_views
@@ -65,3 +66,6 @@ urlpatterns = [
     ),
     path("api/", include(api_endpoints)),
 ]
+
+if settings.ENABLE_MCP_SERVER:
+    urlpatterns.append(path("docs/mcp", views.docs_mcp, name="docs_mcp"))

--- a/core/views.py
+++ b/core/views.py
@@ -421,6 +421,10 @@ def manage_schema_publish(request, schema_id):
     )
 
 
+def docs_mcp(request):
+    return render(request, "core/docs/mcp.html")
+
+
 def about(request):
     return render(request, "core/about.html")
 

--- a/core/views.py
+++ b/core/views.py
@@ -426,6 +426,9 @@ def docs_api(request):
 
 
 def docs_mcp(request):
+    if not settings.ENABLE_MCP_SERVER:
+        raise Http404()
+
     return render(request, "core/docs/mcp.html")
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -421,6 +421,10 @@ def manage_schema_publish(request, schema_id):
     )
 
 
+def docs_api(request):
+    return render(request, "core/docs/api.html")
+
+
 def docs_mcp(request):
     return render(request, "core/docs/mcp.html")
 

--- a/manage.py
+++ b/manage.py
@@ -39,6 +39,7 @@ def main():
             host="127.0.0.1",
             port=port,
             reload=True,
+            reload_includes=["*.html", "*.css"],
         )
         return
 

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -75,6 +75,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "core.context_processors.export_feature_flags",
             ],
         },
     },

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -452,6 +452,12 @@ def test_homepage_no_query_lists_alphabetically():
     assert names == ["AAA First Schema", "ZZZ Last Schema"]
 
 
+@override_settings(ENABLE_MCP_SERVER=True)
+def test_mcp_docs_available_when_feature_flag_enabled():
+    response = Client().get("/docs/mcp")
+    assert response.status_code == 200
+
+
 @override_settings(ENABLE_MCP_SERVER=False)
 def test_mcp_docs_404_when_feature_flag_disabled():
     response = Client().get("/docs/mcp")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,7 +15,7 @@ from tests.factories import (
 )
 from core.models import Schema, DocumentationItem, Profile
 from core.forms import PermanentURLForm
-from django.test import Client
+from django.test import Client, override_settings
 from pytest_django.asserts import assertRedirects
 from unittest.mock import patch
 from utils import assert_schema_matches_manifest
@@ -450,3 +450,30 @@ def test_homepage_no_query_lists_alphabetically():
     SchemaRefFactory(schema=first_schema)
     names = [s.name for s in Client().get("/").context["schemas"]]
     assert names == ["AAA First Schema", "ZZZ Last Schema"]
+
+
+@override_settings(ENABLE_MCP_SERVER=False)
+def test_mcp_docs_404_when_feature_flag_disabled():
+    response = Client().get("/docs/mcp")
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(ENABLE_MCP_SERVER=False)
+def test_mcp_docs_not_linked_in_footer_when_feature_flag_disabled():
+    response = Client().get("/")
+    assert response.status_code == 200
+    assert "Schemas.Pub" in str(response.content)
+    assert "MCP" not in str(response.content)
+
+
+@pytest.mark.django_db
+@override_settings(ENABLE_MCP_SERVER=False)
+def test_mcp_docs_not_linked_from_api_key_page_when_feature_flag_disabled():
+    user = UserFactory.create()
+    client = Client()
+    client.force_login(user)
+    response = client.get("/account/api-key/")
+    assert response.status_code == 200
+    assert "Manage API Key" in str(response.content)
+    assert "MCP" not in str(response.content)


### PR DESCRIPTION
Closes #300.

Adds a documentation page for the MCP server. The page is only available when the `ENABLE_MCP_SERVER` flag is `True`.

I also moved the API docs from `/api/docs` to `/docs/api` alongside the new `/docs/mcp`.

<img width="1275" height="1319" alt="image" src="https://github.com/user-attachments/assets/19b181ef-0045-4b78-a1ba-9dc2c4cf6df9" />
