### PR TITLE
Ensure MCP db connections are cleaned up

### DIFF
--- a/core/mcp/api_key_authentication.py
+++ b/core/mcp/api_key_authentication.py
@@ -1,6 +1,6 @@
 # core/mcp/middleware.py
 import logging
-from asgiref.sync import sync_to_async
+from core.mcp.sync_to_async_with_db_cleanup import sync_to_async_with_db_cleanup
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
@@ -30,7 +30,9 @@ class MCPAPIKeyAuthenticationMiddleware(BaseHTTPMiddleware):
             )
 
         # Safely wrap the synchronous ORM call
-        api_key_obj = await sync_to_async(APIKey.objects.get_from_key)(api_key_header)
+        api_key_obj = await sync_to_async_with_db_cleanup(APIKey.objects.get_from_key)(
+            api_key_header
+        )
 
         if not api_key_obj:
             return JSONResponse(
@@ -42,14 +44,16 @@ class MCPAPIKeyAuthenticationMiddleware(BaseHTTPMiddleware):
             )
 
         # Fetch profile and user safely in an async context
-        @sync_to_async
+        @sync_to_async_with_db_cleanup
         def get_profile_and_user(key_obj):
             return key_obj.profile, key_obj.profile.user
 
         profile, user = await get_profile_and_user(api_key_obj)
 
         # Safely wrap the synchronous rate limiting logic
-        allowed, reason = await sync_to_async(check_and_record_request)(profile)
+        allowed, reason = await sync_to_async_with_db_cleanup(check_and_record_request)(
+            profile
+        )
 
         if not allowed:
             return JSONResponse(

--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from django.utils import timezone
 from mcp.server.fastmcp import FastMCP
 from core.models import Schema
-from asgiref.sync import sync_to_async
+from core.mcp.sync_to_async_with_db_cleanup import sync_to_async_with_db_cleanup
 from core.mcp.context import current_user
 
 mcp = FastMCP(
@@ -45,7 +45,7 @@ MAX_PAGE_SIZE = 10
 
 
 @mcp.tool()
-@sync_to_async
+@sync_to_async_with_db_cleanup
 def search_schemas(
     query: str | None = None, scope: Literal["all", "user"] = "all", page: int = 1
 ):
@@ -118,7 +118,7 @@ async def get_schema(schema_id: int):
 
     user = current_user.get()
 
-    @sync_to_async
+    @sync_to_async_with_db_cleanup
     def fetch_from_db():
         try:
             schema = (
@@ -172,7 +172,7 @@ async def create_schema(manifest: str):
     """
     user = ensure_current_user()
 
-    @sync_to_async
+    @sync_to_async_with_db_cleanup
     def do_create():
         schema = Schema(created_by=user)
         return _validate_manifest_and_update_schema(manifest, schema)
@@ -188,7 +188,7 @@ async def update_schema(schema_id: int, manifest: str):
     """
     user = ensure_current_user()
 
-    @sync_to_async
+    @sync_to_async_with_db_cleanup
     def do_update():
         try:
             schema = Schema.objects.get(pk=schema_id)

--- a/core/mcp/sync_to_async_with_db_cleanup.py
+++ b/core/mcp/sync_to_async_with_db_cleanup.py
@@ -1,0 +1,26 @@
+import functools
+from asgiref.sync import sync_to_async
+from django.db import close_old_connections
+
+
+def sync_to_async_with_db_cleanup(func=None, **kwargs):
+    """
+    A wrapper around sync_to_async that ensures database connections
+    are safely closed before and after the synchronous function executes
+    in the background thread pool.
+    """
+
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(*args, **inner_kwargs):
+            close_old_connections()
+            try:
+                return f(*args, **inner_kwargs)
+            finally:
+                close_old_connections()
+
+        return sync_to_async(wrapper, **kwargs)
+
+    if func is None:
+        return decorator
+    return decorator(func)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,33 +1,8 @@
 import pytest
 from django.core.cache import cache
 from django.test import Client
-from django.db import connection
 import requests_mock as requests_mock_lib
 from factories import ProfileFactory
-
-
-@pytest.fixture(scope="session", autouse=True)
-def force_terminate_db_connections(django_db_setup, django_db_blocker):
-    """
-    Hooks into pytest-django's teardown lifecycle.
-    Guarantees that all background thread connections are killed
-    before pytest tries to drop the test database.
-    """
-    yield
-
-    with django_db_blocker.unblock():
-        with connection.cursor() as cursor:
-            db_name = connection.settings_dict["NAME"]
-            cursor.execute(
-                f"""
-                SELECT pg_terminate_backend(pg_stat_activity.pid)
-                FROM pg_stat_activity
-                WHERE pg_stat_activity.datname = '{db_name}'
-                  AND pid <> pg_backend_pid();
-                """
-            )
-
-        connection.close()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -2,7 +2,6 @@ import pytest
 import json
 import requests_mock
 from mcp.shared.memory import create_connected_server_and_client_session
-from asgiref.sync import sync_to_async
 from unittest.mock import patch, MagicMock
 from starlette.responses import JSONResponse
 from django.test import override_settings
@@ -11,6 +10,9 @@ from core.mcp.api_key_authentication import MCPAPIKeyAuthenticationMiddleware
 from factories import SchemaFactory, ProfileFactory, UserFactory, SchemaRefFactory
 from utils import assert_schema_matches_manifest
 from core.models import Schema
+from core.mcp.sync_to_async_with_db_cleanup import (
+    sync_to_async_with_db_cleanup as sync_to_async,
+)
 
 
 # Force all database tests in this file to flush tables instead of rolling back,


### PR DESCRIPTION
Closes #302.

Adds a new decorator `sync_to_async_with_db_cleanup` which wraps `sync_to_async` but also ensures Django database connections are cleaned up after use. Django normally does this for us, but because we're doing MCP operations outside of Django and in a worker, we need to clean these connections up ourselves.