### PR TITLE
Enable MCP server on staging

### DIFF
--- a/schemaindex/asgi.py
+++ b/schemaindex/asgi.py
@@ -18,6 +18,33 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "schemaindex.settings.development")
 
+"""
+To avoid various complexities with trying to run the MCP server *inside* our Django app,
+we run it *alongside* Django, inside a small Starlette app which mostly just routes requests.
+
+Our full ASGI application looks something like this:
+
+
+      incoming requests
+             |
+             |
+             v
+    [Parent Starlette app]
+       |              |
+       |              |
+    requests       everything
+    to /mcp*         else
+       |              |
+       |              |
+       v              v
+  [MCP server]---->[Django]
+               ^
+               |
+    (the MCP server uses Django models
+    to interact with the Django database)
+
+"""
+
 
 def create_application():
     django_app = get_asgi_application()
@@ -44,8 +71,9 @@ def create_application():
         async with mcp.session_manager.run():
             yield
 
-    # Wrap the FastMCP streamable app with the API key middleware
     mcp_app = mcp.streamable_http_app()
+
+    # Wrap the FastMCP streamable app with the API key middleware
     mcp_app_with_auth = Starlette(
         routes=mcp_app.routes,
         middleware=[Middleware(MCPAPIKeyAuthenticationMiddleware)],

--- a/schemaindex/settings/staging.py
+++ b/schemaindex/settings/staging.py
@@ -16,3 +16,4 @@ for key in STORAGES:
 # Buckets URLs for static and media files
 STATIC_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/site-assets/"
 MEDIA_URL = f"https://storage.googleapis.com/{GS_BUCKET_NAME}/schemas/"
+ENABLE_MCP_SERVER = True


### PR DESCRIPTION
Turns out #298 might be unnecessary while we're on v1 of the SDK (see #318). There is a `host` property for the MCP server but [this official example](https://github.com/modelcontextprotocol/python-sdk/blob/v1.x/examples/snippets/servers/streamable_http_host_mounting.py) doesn't use it even when setting up host-based routing. So, let's just enable the MCP server on staging and see if it works!

