### PR TITLE
MCP response improvements

### DIFF
--- a/core/mcp/server.py
+++ b/core/mcp/server.py
@@ -31,12 +31,14 @@ def format_schema(schema):
     formatted_schema = f"""
 ID: {schema.id}
 Name: {schema.name}
+Resource URI: schema://{schema.id}
+URL: https://schemas.pub{reverse("schema_detail", kwargs={"schema_id": schema.id})}
 """
-    if schema.description:
-        formatted_schema += f"Description: {schema.description}\n"
-
     if schema.published_at is None or schema.published_at > timezone.now():
         formatted_schema += "Visibility: Private\n"
+
+    if schema.description:
+        formatted_schema += f"Description: {schema.description}\n"
 
     return formatted_schema
 
@@ -63,7 +65,7 @@ def search_schemas(
     query: str | None = None, scope: Literal["all", "user"] = "all", page: int = 1
 ):
     """
-    Search for schemas.
+    Browse and search for schemas.
 
     Args:
       query: A search query. Can be a list of keywords or an $id. Pass None or an empty string to list all schemas in scope.
@@ -165,10 +167,6 @@ def _validate_manifest_and_update_schema(manifest, schema):
     try:
         manifest_data = Schema.validate_manifest(manifest)
         schema.overwrite_from_manifest(manifest_data)
-        return {
-            "id": schema.id,
-            "url": reverse("schema_detail", kwargs={"schema_id": schema.id}),
-        }
     except json.JSONDecodeError as e:
         raise ValueError(f"Undecodable JSON payload: {e.msg}")
     except JSONValidationError as e:
@@ -188,7 +186,10 @@ async def create_schema(manifest: str):
     @sync_to_async_with_db_cleanup
     def do_create():
         schema = Schema(created_by=user)
-        return _validate_manifest_and_update_schema(manifest, schema)
+        _validate_manifest_and_update_schema(manifest, schema)
+        response = "Schema created successfully:\n\n"
+        response += format_schema(schema)
+        return response
 
     return await do_create()
 
@@ -210,6 +211,9 @@ async def update_schema(schema_id: int, manifest: str):
         except Schema.DoesNotExist:
             raise ValueError(f"Schema with ID '{schema_id}' not found.")
 
-        return _validate_manifest_and_update_schema(manifest, schema)
+        _validate_manifest_and_update_schema(manifest, schema)
+        response = "Schema updated successfully:\n\n"
+        response += format_schema(schema)
+        return response
 
     return await do_update()

--- a/core/templates/core/docs/mcp.html
+++ b/core/templates/core/docs/mcp.html
@@ -10,9 +10,14 @@ Schemas.Pub - MCP Documentation
     Schemas.Pub provides a Model Context Protocol (MCP) server that allows MCP-compatible clients to search for, create, and update schemas directly.
   </p>
 
+  <h2>Connection</h2>
+  <p>
+    Configure your MCP client to connect at <code>{{ request.scheme }}://{{ request.get_host }}/mcp/</code>
+  </p>
+
   <h2>Authentication</h2>
   <p>
-    All requests to the MCP server require an X-API-Key header with a valid API key.
+    All requests to the MCP server require an <code>X-API-Key</code> header with a valid API key.
   {% if request.user %}
   You can create or manage your API key <a href="{% url 'account_api_key' %}">here</a>.
   {% else %}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,5 +1,6 @@
 import pytest
 import json
+import re
 import requests_mock
 from mcp.shared.memory import create_connected_server_and_client_session
 from unittest.mock import patch, MagicMock
@@ -194,12 +195,10 @@ async def test_create_schema_success(client_session, current_user_mock):
     result = await client_session.call_tool(
         "create_schema", arguments={"manifest": manifest_str}
     )
-
-    parsed_result = json.loads(result.content[0].text)
-    assert "id" in parsed_result
-    assert "url" in parsed_result
-
-    schema = await sync_to_async(Schema.objects.get)(id=parsed_result["id"])
+    match = re.search(r"ID:\s*(\d+)", result.content[0].text)
+    assert match
+    schema_id = int(match.group(1))
+    schema = await sync_to_async(Schema.objects.get)(id=schema_id)
     await sync_to_async(assert_schema_matches_manifest)(schema, manifest)
 
 
@@ -294,14 +293,12 @@ async def test_update_schema_success(client_session, current_user_mock):
     result = await client_session.call_tool(
         "update_schema", arguments={"schema_id": schema.id, "manifest": manifest_str}
     )
-
-    parsed_result = json.loads(result.content[0].text)
-    assert "id" in parsed_result
-    assert "url" in parsed_result
-    assert parsed_result["id"] == schema.id
-
-    updated_schema = await sync_to_async(Schema.objects.get)(id=parsed_result["id"])
-    await sync_to_async(assert_schema_matches_manifest)(updated_schema, manifest)
+    match = re.search(r"ID:\s*(\d+)", result.content[0].text)
+    assert match
+    schema_id = int(match.group(1))
+    assert schema_id == schema.id
+    await sync_to_async(schema.refresh_from_db)()
+    await sync_to_async(assert_schema_matches_manifest)(schema, manifest)
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #326. Closes #323.

#326: Updates the MCP tool responses to include the `schema://<id>` resource URI since resource templates aren't enumerable by Claude Code for some reason (https://github.com/anthropics/claude-code/issues/3122). As part of this change, I updated the `create_` and `update_` tools to return the same plaintext format that `search_schemas` uses. I'm not actually sure whether plaintext vs something like JSON or XML is easier for the model (I suspect it depends on the model), but this way we just have one `format_schema` function that's used by all our tools when surfacing a schema.

#323: Just adds the actual MCP connection URL to the docs.

