### PR TITLE
Show total (matching) schema count on homepage when it exceeds what we show

### DIFF
--- a/core/templates/core/index.html
+++ b/core/templates/core/index.html
@@ -101,13 +101,27 @@ Schemas.Pub - A public schema registry
     {% endfor %}
   </ul>
   <div class="content-row schema-count">
+    {% comment %}
+    Construct a status like "Showing N schemas."
+    If there's a search query or filter, expand to "Showing N matching schemas."
+    If there are more results than we can show, expand to "Showing N of M schemas,"
+    or "Showing N of M matching schemas" if there's a search query/filter.
+    {% endcomment %}
     {% if schemas|length > 0 %}
-      Showing {{ schemas | length }}
-      {% if request.GET.search_query or request.GET.specification_file_type or request.GET.documentation_role %} matching
+      Showing {{ schemas|length }}
+      {% if matching_schema_count > schemas|length %}
+      of {{ matching_schema_count }} 
       {% endif %}
-      schema{{ schemas | pluralize }}
+      {% if request.GET.search_query or request.GET.specification_file_type or request.GET.documentation_role %}
+      matching 
+      {% endif %}
+      schema{{ matching_schema_count|pluralize }}
     {% else %}
-    No {% if request.GET.search_query or request.GET.specification_file_type or request.GET.documentation_role %} matching {% endif %} schemas
+    No 
+      {% if request.GET.search_query or request.GET.specification_file_type or request.GET.documentation_role %}
+      matching 
+      {% endif %}
+      schemas
     {% endif %}
   </div>
 </main>

--- a/core/views.py
+++ b/core/views.py
@@ -160,6 +160,7 @@ def index(request):
         "core/index.html",
         {
             "schemas": filtered_by_specification_file_type[:MAX_SCHEMA_RESULT_COUNT],
+            "matching_schema_count": len(filtered_by_specification_file_type),
             "documentation_roles": [
                 DocumentationItem.DocumentationItemRole.RFC,
                 DocumentationItem.DocumentationItemRole.W3C,


### PR DESCRIPTION
Closes #308.

Updates our schema count to show "of M schemas" or "of M matching schemas" when the results exceed the limit of what we show.

Screenshots where I lowered the max results to 2:

<img width="992" height="425" alt="Screenshot From 2026-08-17 11-21-27" src="https://github.com/user-attachments/assets/83eb7fc9-e7a2-4016-848f-584ec1e54da2" />

<img width="992" height="425" alt="image" src="https://github.com/user-attachments/assets/55b92004-cad8-4aa0-9636-f4bf80a23f9f" />

