### PR TITLE
Enable MCP on production

### DIFF
--- a/schemaindex/settings/production.py
+++ b/schemaindex/settings/production.py
@@ -113,3 +113,4 @@ EMAIL_HOST_USER = "noreply@dtinit.org"
 EMAIL_HOST_PASSWORD = env.str("EMAIL_HOST_PASSWORD")
 DEFAULT_FROM_EMAIL = "noreply@dtinit.org"
 SERVER_EMAIL = "noreply@dtinit.org"
+ENABLE_MCP_SERVER = True


### PR DESCRIPTION
Just enables the feature flag for MCP in production.

Here's a chat log from a test I ran with Claude Code against staging:

```
❯ I'd like us to create a new schema and add it to schemas.pub, just to test    
  out the process.                                                              

● readMcpResource(Read resource "schema://manifest.json" from server
                 "schemas_pub")
  ⎿  {
       "contents": [
         {
     … +54 lines (ctrl+o to expand)

  Called schemas.pub 4 times (ctrl+o to expand)

● readMcpResource(Read resource "schema://1" from server "schemas_pub")
  ⎿  {
       "contents": [
         {
     … +13 lines (ctrl+o to expand)

● Now I understand the format. These reference real hosted URLs (e.g., raw
  GitHub JSON schema files, RFC docs). Let me check what a good test schema
  would look like for you.

● User answered Claude's questions:
  ⎿  · What schema do you want to create for this test? I need an actual JSON 
     Schema definition document hosted at a URL (like a raw GitHub link) to 
     point to. → Let's just make up some URLs like "example.com/whatever." We'll
     keep the schema private so it won't matter; we're just testing.

  Called schemas.pub (ctrl+o to expand)

● Created successfully: Test Schema (ID 3, private) at schema://3 /
  https://schemas.pub/schemas/3, pointing to a made-up definition URL
  (https://example.com/schemas/test-schema.json). Since it's private, it won't
  show in public search, but you can fetch or update it via schema://3.

✻ Cooked for 34s

❯ Let's try an update now too, just to test. Maybe change the title and/or add  
  a (nonexistent) readme?                                                       

  Called schemas.pub (ctrl+o to expand)

● Update worked — schema 3 is now named "Test Schema (Updated)" with a readme
  document added alongside the original definition. Both create and update flows
  are confirmed working.

✻ Worked for 6s

❯ Now let's try searching for our schema                                        

  Called schemas.pub (ctrl+o to expand)

● Found it with scope: user — as expected, it doesn't show under scope: all
  since it's private. That confirms create, update, and search all work as
  intended.

✻ Worked for 4s

❯ Wait, shouldn't it show up with scope all?                                    

● Good question — let me actually check that rather than assume.

  Called schemas.pub (ctrl+o to expand)

● It does show up under scope: all too — I was wrong earlier. Makes sense: "all"
  for you as the owner includes your own private schemas plus the public
  registry; "all" scoped to some other user presumably wouldn't show it. So
  scope mainly matters for filtering to just your own vs. everything you can
  see, not for hiding your private items from yourself.

✻ Sautéed for 6s

❯ I want to keep it private, but anything I should know about making schemas    
  public in the future?                                                         

● From the manifest schema definition I read earlier: once you set public: true,
  it's irreversible — a schema can't be made private again or deleted, except
  by a Schemas.Pub administrator. So before flipping that flag, make sure the
  name, description, and documents are actually correct/final, since an update
  can still edit content afterward but you can't undo the public visibility
  itself.

```