### PR TITLE
Alex 312 trusted content hosts followup

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -2,11 +2,13 @@ import json
 from django import forms
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+from django.conf import settings
 import requests
 from .models import DocumentationItem, SchemaRef, Schema, PermanentURL
 from .utils import (
     guess_specification_language_by_extension,
     is_trusted_content_host_url,
+    human_readable_list,
 )
 
 
@@ -65,7 +67,7 @@ class SchemaRefForm(ReferenceItemForm):
     )
     url = forms.URLField(
         label="URL",
-        help_text=f"Accepted formats: {', '.join(sorted(EXPLICITLY_SUPPORTED_FILE_EXTENSIONS))}",
+        help_text=f"Accepted formats: {human_readable_list(sorted(EXPLICITLY_SUPPORTED_FILE_EXTENSIONS))}. Schemas.Pub displays file content from the following domains: {human_readable_list(sorted(settings.TRUSTED_CONTENT_DOMAINS))}.",
     )
 
     def clean_url(self):
@@ -179,6 +181,7 @@ class SchemaForm(forms.Form):
     )
     readme_url = forms.URLField(
         label="README URL",
+        help_text=f"Schemas.Pub displays README content from the following domains: {human_readable_list(sorted(settings.TRUSTED_CONTENT_DOMAINS))}",
         widget=forms.TextInput(attrs={"placeholder": "https://example.com/README.md"}),
     )
     readme_format = forms.ChoiceField(

--- a/core/models.py
+++ b/core/models.py
@@ -637,7 +637,7 @@ class ReferenceItem(BaseModel):
                     raise last_exception  # Re-raise the last exception after all retries and email logic
 
     def get_content(self):
-        if not is_trusted_content_host_url(self._get_content_url()):
+        if not self.is_content_fetchable:
             return ""
 
         # Fetch remote file content, using cache when available
@@ -701,6 +701,10 @@ class ReferenceItem(BaseModel):
     @property
     def url_provider_info(self):
         return URLProviderInfo.from_url(self.url)
+
+    @property
+    def is_content_fetchable(self):
+        return is_trusted_content_host_url(self._get_content_url())
 
 
 class SchemaRef(ReferenceItem):

--- a/core/static/css/site.css
+++ b/core/static/css/site.css
@@ -969,6 +969,11 @@ a.badge--w3c {
   padding: 1rem;
 }
 
+.schema-layout .schema-layout__content .external-readme-link h2 {
+  color: #fff;
+  padding-bottom: 1rem;
+}
+
 .schema-layout .schema-layout__extra {
   flex-shrink: 0;
   width: 17rem;

--- a/core/templates/core/schemas/detail.html
+++ b/core/templates/core/schemas/detail.html
@@ -6,7 +6,7 @@
 
 {% block schema_content %}
 <div>
-  {% if latest_readme.format == 'markdown' or latest_readme.format == 'plaintext' %}
+  {% if latest_readme.is_content_fetchable and latest_readme.format == 'markdown' or latest_readme.format == 'plaintext' %}
     {% if not latest_readme_content %}
     {% include "core/partials/content_fetch_error.html" with message="We're having trouble fetching the README content from the source. You can try viewing it directly:" item=latest_readme only %}
     {% elif latest_readme.format == 'markdown' %}
@@ -34,9 +34,9 @@
     {% endif %}
   {% elif latest_readme %}
   <div class="external-readme-link">
+    <h2>README</h2>
     <a href="{{ latest_readme|try_github_repo_url }}" class="text-with-icon">
-      View external README
-      {{ latest_readme|branded_external_link_icon_for_reference_item }}
+      {{ latest_readme|try_github_repo_url }}
     </a>
   </div>
   {% endif %}

--- a/core/templates/core/schemas/detail_schema_ref.html
+++ b/core/templates/core/schemas/detail_schema_ref.html
@@ -21,20 +21,26 @@
   {% else %}
   <h2>Unnamed definition</h2>
   {% endif %}
-  {% if not schema_ref.markdown and not schema_ref.content %}
-  {% include "core/partials/content_fetch_error.html" with message="We're having trouble fetching this definition from the source. You can try viewing it directly:" item=schema_ref only %}
-  {% elif schema_ref.markdown %}
-  <div class="markdown">
-    {{ schema_ref.markdown }}
-  </div>
+  {% if schema_ref.is_content_fetchable %}
+    {% if not schema_ref.markdown and not schema_ref.content %}
+    {% include "core/partials/content_fetch_error.html" with message="We're having trouble fetching this definition from the source. You can try viewing it directly:" item=schema_ref only %}
+    {% elif schema_ref.markdown %}
+    <div class="markdown">
+      {{ schema_ref.markdown }}
+    </div>
+    {% else %}
+    <!-- Please don't add whitespace to this line!-->
+    <pre class="schema-definition"><code>{{ schema_ref.content|escape }}</code></pre>
+    {% endif %}
+    <hr />
+    <p>
+      <a href="{{ schema_ref|try_github_repo_url }}" class="text-with-icon">View source{{ schema_ref|branded_external_link_icon_for_reference_item }}</a>
+    </p>
   {% else %}
-  <!-- Please don't add whitespace to this line!-->
-  <pre class="schema-definition"><code>{{ schema_ref.content|escape }}</code></pre>
-  {% endif %}
-  <hr />
   <p>
-    <a href="{{ schema_ref|try_github_repo_url }}" class="text-with-icon">View source{{ schema_ref|branded_external_link_icon_for_reference_item }}</a>
+    <a href="{{ schema_ref|try_github_repo_url }}" class="text-with-icon">{{schema_ref|try_github_repo_url}}</a>
   </p>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -93,3 +93,14 @@ def is_trusted_content_host_url(url):
     return any(
         hostname.endswith("." + domain) for domain in settings.TRUSTED_CONTENT_DOMAINS
     )
+
+
+def human_readable_list(items):
+    """Join a list of strings into a human-readable list with an Oxford comma."""
+    if not items:
+        return ""
+    if len(items) == 1:
+        return items[0]
+    if len(items) == 2:
+        return f"{items[0]} and {items[1]}"
+    return f"{', '.join(items[:-1])}, and {items[-1]}"

--- a/core/views.py
+++ b/core/views.py
@@ -173,7 +173,7 @@ def index(request):
 def schema_detail(request, schema):
     latest_readme = schema.latest_readme()
     latest_readme_content = None
-    if latest_readme:
+    if latest_readme and latest_readme.is_content_fetchable:
         try:
             response_text = latest_readme.get_content()
             if (
@@ -211,17 +211,18 @@ def schema_detail(request, schema):
 @lookup_schema
 def schema_ref_detail(request, schema, schema_ref_id):
     schema_ref = get_object_or_404(schema.schemaref_set.filter(id=schema_ref_id))
-    try:
-        text_content = schema_ref.get_content()
-        if schema_ref.language == "markdown":
-            schema_ref.markdown = render_markdown(text_content)
-        else:
-            schema_ref.content = escape(text_content)
-    except requests.exceptions.RequestException:
-        logging.error(
-            f"Failed to fetch content for schema_ref {schema_ref.id} (url={schema_ref.url})",
-            exc_info=True,
-        )
+    if schema_ref.is_content_fetchable:
+        try:
+            text_content = schema_ref.get_content()
+            if schema_ref.language == "markdown":
+                schema_ref.markdown = render_markdown(text_content)
+            else:
+                schema_ref.content = escape(text_content)
+        except requests.exceptions.RequestException:
+            logging.error(
+                f"Failed to fetch content for schema_ref {schema_ref.id} (url={schema_ref.url})",
+                exc_info=True,
+            )
 
     return render(
         request,

--- a/schemaindex/settings/base.py
+++ b/schemaindex/settings/base.py
@@ -199,9 +199,7 @@ ENABLE_MCP_SERVER = False
 TRUSTED_CONTENT_DOMAINS = [
     "github.com",
     "githubusercontent.com",
-    "w3.org",
-    "happenstance.ai",
-    "osirisjson.org",
     "ietf.org",
     "rfc-editor.org",
+    "w3.org",
 ]


### PR DESCRIPTION
Closes #312.

Updates UI to explain when file content is actually displayed on Schemas.Pub and more gracefully handle when it isn't.

How detail pages will look when we can't safely fetch the file content:
<img width="1275" height="606" alt="Screenshot From 2026-08-17 15-33-09" src="https://github.com/user-attachments/assets/4a4c9e9a-fba0-4856-8998-a1e25a086a1f" />
<img width="1275" height="606" alt="Screenshot From 2026-08-17 15-33-16" src="https://github.com/user-attachments/assets/4d1cca17-77ba-43b7-b16b-f099935600e7" />

How the schema management form notifies users of trusted content domains:
<img width="987" height="487" alt="image" src="https://github.com/user-attachments/assets/6ccb9ca8-0bdb-498d-b044-c3374a8780c1" />


Note: I removed a couple of our `TRUSTED_CONTENT_DOMAINS` entries which were added as port of the original issue mitigation (#311) as I wasn't sure they belonged in our help text with domains like GitHub and W3.org. We might consider creating a subset of `TRUSTED_CONTENT_DOMAINS` like `ADVERTISED_TRUSTED_CONTENT_DOMAINS` which we can use for UI copy while still supporting a larger list with additional special cases.